### PR TITLE
Store uids instead of IDs in practice stats DB.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trane"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "An automated system for learning complex skills"
 license = "GPL-3.0"


### PR DESCRIPTION
Size grows quickly if the raw IDs are stored in every row. Instead, have
a table of uids which store the IDs and have the other table reference
it when looking up scores.

Breaking change. DBs created in previous versions won't work.