### PR TITLE
Fix multiple bugs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,14 +240,8 @@ impl ExerciseScheduler for Trane {
         self.scheduler.get_exercise_batch(filter)
     }
 
-    fn record_exercise_score(
-        &self,
-        exercise_id: &str,
-        score: MasteryScore,
-        timestamp: i64,
-    ) -> Result<()> {
-        self.scheduler
-            .record_exercise_score(exercise_id, score, timestamp)
+    fn score_exercise(&self, exercise_id: &str, score: MasteryScore, timestamp: i64) -> Result<()> {
+        self.scheduler.score_exercise(exercise_id, score, timestamp)
     }
 }
 

--- a/src/scheduler/data.rs
+++ b/src/scheduler/data.rs
@@ -225,9 +225,9 @@ impl SchedulerData {
                 ) {
                     // There's no lesson nor course filter, so the course passes the filter.
                     (None, None) => Ok(true),
-                    //  There's only a lesson filter. Return true so that the lessons in the course
-                    //  are reached by the search.
-                    (Some(_), None) => Ok(true),
+                    //  There's only a lesson filter. Return false so that the the course is skipped
+                    //  and the decision is made based on the lesson.
+                    (Some(_), None) => Ok(false),
                     // There's only a course filter, so return whether the course passed the filter.
                     (None, Some(_)) => Ok(course_passes.unwrap_or(false)),
                     // There's both a lesson and course filter. The behavior depends on the logical
@@ -235,9 +235,9 @@ impl SchedulerData {
                     (Some(_), Some(_)) => match metadata_filter.op {
                         // If the op is All, return whether the course passed the filter.
                         FilterOp::All => Ok(course_passes.unwrap_or(false)),
-                        // If the op is Any, return true because the metadata in the lessons
-                        // ultimately decides whether the lessons pass the filter.
-                        FilterOp::Any => Ok(true),
+                        // If the op is Any, return false so that the course is skipped and the
+                        // decision is made based on the lesson.
+                        FilterOp::Any => Ok(false),
                     },
                 }
             }

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -32,7 +32,7 @@ pub struct SimpleScorer {}
 impl ExerciseScorer for SimpleScorer {
     fn score(&self, previous_trials: Vec<ExerciseTrial>) -> Option<f32> {
         if previous_trials.is_empty() {
-            return None;
+            return Some(0.0);
         }
 
         let now = Utc::now();

--- a/src/scorer/test.rs
+++ b/src/scorer/test.rs
@@ -13,7 +13,7 @@ fn generate_timestamp(num_days: i64) -> i64 {
 
 #[test]
 fn no_previous_trials() {
-    assert_eq!(None, SCORER.score(vec![]))
+    assert_eq!(Some(0.0), SCORER.score(vec![]))
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -335,7 +335,53 @@ lazy_static! {
                     num_exercises: 10,
                 },
             ],
-        }
+        },
+        TestCourse {
+            id: TestId(7, None, None),
+            dependencies: vec![],
+            metadata: BTreeMap::from([
+                (
+                    "course_key_1".to_string(),
+                    vec!["course_key_1:value_1".to_string()]
+                ),
+                (
+                    "course_key_2".to_string(),
+                    vec!["course_key_2:value_1".to_string()]
+                ),
+            ]),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(7, Some(0), None),
+                    dependencies: vec![TestId(0, None, None)],
+                    metadata: BTreeMap::from([
+                        (
+                            "lesson_key_1".to_string(),
+                            vec!["lesson_key_1:value_1".to_string()]
+                        ),
+                        (
+                            "lesson_key_2".to_string(),
+                            vec!["lesson_key_2:value_1".to_string()]
+                        ),
+                    ]),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(7, Some(1), None),
+                    dependencies: vec![TestId(0, Some(0), None)],
+                    metadata: BTreeMap::from([
+                        (
+                            "lesson_key_1".to_string(),
+                            vec!["lesson_key_1:value_2".to_string()]
+                        ),
+                        (
+                            "lesson_key_2".to_string(),
+                            vec!["lesson_key_2:value_2".to_string()]
+                        ),
+                    ]),
+                    num_exercises: 10,
+                },
+            ],
+        },
     ];
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -258,7 +258,7 @@ impl TraneSimulation {
             let (exercise_id, _) = batch.pop().unwrap();
             let score = (self.answer_closure)(&exercise_id);
             if score.is_some() {
-                trane.record_exercise_score(
+                trane.score_exercise(
                     &exercise_id,
                     score.clone().unwrap(),
                     Utc::now().timestamp(),


### PR DESCRIPTION
- Non-blacklisted courses were accidentally receiving a None score.
- Changing name `ExerciseScheduler::record_exercise_score` because it was colliding with
   `PracticeStats::record_exercise_score`, causing the score cache to not be updated.
- An exercise with no previous scores now has a score of 0.0 instead of None.
- Ignore a lesson's dependency on its course when deciding if all the dependencies are
  satisfied.
- A metadata filter with course and lesson filters will return false for the course so that the
  course is skipped and the decision is made when the lesson is reached. Otherwise, exercises
  in the course that do not match the filter were being added.
- Added a regression test in basic_tests.