### PR TITLE
Remove implicit dependencies.

### DIFF
--- a/src/blacklist.rs
+++ b/src/blacklist.rs
@@ -53,7 +53,7 @@ impl BlackListDB {
             .with_context(|| "failed to initialize blacklist DB")
     }
 
-    /// A constructor taking a SQLite connection.
+    /// A constructor taking a connection manager.
     fn new(connection_manager: SqliteConnectionManager) -> Result<BlackListDB> {
         let pool = Pool::new(connection_manager)?;
         let mut blacklist = BlackListDB {


### PR DESCRIPTION
There's no need to add these dependencies to the graph because the
scheduler already takes care of only adding the starting lessons
when a course is first encountered.