### PR TITLE
Cache lesson scores

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -47,6 +47,9 @@ pub trait UnitGraph {
     /// Returns the exercises belonging to the given lesson.
     fn get_lesson_exercises(&self, lesson_id: &Ustr) -> Option<UstrSet>;
 
+    /// Returns the lesson to which the given exercise belongs.
+    fn get_exercise_lesson(&self, exercise_id: &Ustr) -> Option<Ustr>;
+
     /// Returns the dependencies of the given unit.
     fn get_dependencies(&self, unit_id: &Ustr) -> Option<UstrSet>;
 
@@ -83,6 +86,9 @@ pub(crate) struct InMemoryUnitGraph {
 
     /// The mapping of a lesson to its exercises.
     lesson_exercise_map: UstrMap<UstrSet>,
+
+    /// The mapping of an exercise to its lesson.
+    exercise_lesson_map: UstrMap<Ustr>,
 
     /// The mapping of a unit to its dependencies.
     dependency_graph: UstrMap<UstrSet>,
@@ -146,6 +152,7 @@ impl UnitGraph for InMemoryUnitGraph {
             .entry(*lesson_id)
             .or_insert_with(UstrSet::default)
             .insert(*exercise_id);
+        self.exercise_lesson_map.insert(*exercise_id, *lesson_id);
         Ok(())
     }
 
@@ -226,6 +233,10 @@ impl UnitGraph for InMemoryUnitGraph {
 
     fn get_lesson_exercises(&self, lesson_id: &Ustr) -> Option<UstrSet> {
         self.lesson_exercise_map.get(lesson_id).cloned()
+    }
+
+    fn get_exercise_lesson(&self, exercise_id: &Ustr) -> Option<Ustr> {
+        self.exercise_lesson_map.get(exercise_id).cloned()
     }
 
     fn get_dependencies(&self, unit_id: &Ustr) -> Option<UstrSet> {

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -43,11 +43,27 @@ fn get_course_lessons_and_exercises() -> Result<()> {
     assert_eq!(lesson1_exercises.len(), 2);
     assert!(lesson1_exercises.contains(&lesson1_exercise1_id));
     assert!(lesson1_exercises.contains(&lesson1_exercise2_id));
+    assert_eq!(
+        graph.get_exercise_lesson(&lesson1_exercise1_id).unwrap(),
+        lesson1_id
+    );
+    assert_eq!(
+        graph.get_exercise_lesson(&lesson1_exercise2_id).unwrap(),
+        lesson1_id
+    );
 
     let lesson2_exercises = graph.get_lesson_exercises(&lesson2_id).unwrap();
     assert_eq!(lesson2_exercises.len(), 2);
     assert!(lesson2_exercises.contains(&lesson2_exercise1_id));
     assert!(lesson2_exercises.contains(&lesson2_exercise2_id));
+    assert_eq!(
+        graph.get_exercise_lesson(&lesson2_exercise1_id).unwrap(),
+        lesson2_id
+    );
+    assert_eq!(
+        graph.get_exercise_lesson(&lesson2_exercise2_id).unwrap(),
+        lesson2_id
+    );
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,14 @@ impl Trane {
 
 impl Blacklist for Trane {
     fn add_unit(&mut self, unit_id: &Ustr) -> Result<()> {
+        self.scheduler.clear_cached_lesson_scores();
+        self.scheduler.invalidate_cached_score(unit_id);
         self.blacklist.write().add_unit(unit_id)
     }
 
     fn remove_unit(&mut self, unit_id: &Ustr) -> Result<()> {
+        self.scheduler.clear_cached_lesson_scores();
+        self.scheduler.invalidate_cached_score(unit_id);
         self.blacklist.write().remove_unit(unit_id)
     }
 
@@ -251,6 +255,14 @@ impl ExerciseScheduler for Trane {
     ) -> Result<()> {
         self.scheduler.score_exercise(exercise_id, score, timestamp)
     }
+
+    fn invalidate_cached_score(&self, unit_id: &Ustr) {
+        self.scheduler.invalidate_cached_score(unit_id)
+    }
+
+    fn clear_cached_lesson_scores(&self) {
+        self.scheduler.clear_cached_lesson_scores()
+    }
 }
 
 impl UnitGraph for Trane {
@@ -297,6 +309,10 @@ impl UnitGraph for Trane {
 
     fn get_lesson_exercises(&self, lesson_id: &Ustr) -> Option<UstrSet> {
         self.unit_graph.read().get_lesson_exercises(lesson_id)
+    }
+
+    fn get_exercise_lesson(&self, exercise_id: &Ustr) -> Option<Ustr> {
+        self.unit_graph.read().get_exercise_lesson(exercise_id)
     }
 
     fn get_dependencies(&self, unit_id: &Ustr) -> Option<UstrSet> {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -34,6 +34,12 @@ pub trait ExerciseScheduler {
     /// Records the score of the given exercise's trial.
     fn score_exercise(&self, exercise_id: &Ustr, score: MasteryScore, timestamp: i64)
         -> Result<()>;
+
+    /// Removes any cached scores for the given unit.
+    fn invalidate_cached_score(&self, unit_id: &Ustr);
+
+    /// Removes any cached lesson scores.
+    fn clear_cached_lesson_scores(&self);
 }
 
 /// A struct representing an element in the stack used during the graph search.
@@ -545,5 +551,13 @@ impl ExerciseScheduler for DepthFirstScheduler {
             .record_exercise_score(exercise_id, score, timestamp)?;
         self.score_cache.invalidate_cached_score(exercise_id);
         Ok(())
+    }
+
+    fn invalidate_cached_score(&self, unit_id: &Ustr) {
+        self.score_cache.invalidate_cached_score(unit_id);
+    }
+
+    fn clear_cached_lesson_scores(&self) {
+        self.score_cache.clear_cached_lesson_scores();
     }
 }

--- a/tests/large_tests.rs
+++ b/tests/large_tests.rs
@@ -111,7 +111,7 @@ fn all_exercises_scheduled_random() -> Result<()> {
         course_dependencies_range: (0, 5),
         lessons_per_course_range: (1, 5),
         lesson_dependencies_range: (0, 5),
-        exercises_per_lesson_range: (1, 10),
+        exercises_per_lesson_range: (1, 20),
     }
     .generate_library();
     let mut trane = init_trane(&temp_dir.path().to_path_buf(), &random_library)?;


### PR DESCRIPTION
Big performance improvement but have to invalidate all the scores when the blacklist is updated
or else the dependent lessons could be incorrectly scheduled/not scheduled.