### PR TITLE
Reduce number of batches needed to schedule all exercises

### DIFF
--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -131,18 +131,18 @@ impl CandidateFilter {
         let (target_selected, _) = Self::select_candidates(target_candidates, remainder)?;
         final_candidates.extend(target_selected);
 
-        // Go through the remainders in descending order of difficulty and add them to the list of
+        // Go through the remainders in ascending order of difficulty and add them to the list of
         // final candidates if there's still space left in the batch.
         Self::add_remainder(
             options.batch_size,
             &mut final_candidates,
-            &current_remainder,
+            &mastered_remainder,
         );
         Self::add_remainder(options.batch_size, &mut final_candidates, &easy_remainder);
         Self::add_remainder(
             options.batch_size,
             &mut final_candidates,
-            &mastered_remainder,
+            &current_remainder,
         );
 
         self.candidates_to_exercises(final_candidates)

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -686,8 +686,8 @@ fn invalidate_cache_on_blacklist_update() -> Result<()> {
 
     // Re-run the first simulation with the same blacklist and verify that the blacklisted exercises
     // are not scheduled anymore. Every other exercise should be scheduled. Run the simulation with
-    // 10000 exercises so that every exercise has a high probability of being scheduled.
-    let mut simulation = TraneSimulation::new(10000, Box::new(|_| Some(MasteryScore::Five)));
+    // 5000 exercises so that every exercise has a high probability of being scheduled.
+    let mut simulation = TraneSimulation::new(5000, Box::new(|_| Some(MasteryScore::Five)));
     simulation.run_simulation(&mut trane, &exercise_blacklist, None)?;
 
     // Every blacklisted exercise should not have been scheduled.


### PR DESCRIPTION
Add the remainders to the batch in ascending order of difficulty (i.e.
mastered exercises are added first). This seems to reduce the number of
batches needed to schedule all the exercises.