### PR TITLE
Fix bug in scheduler

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -500,7 +500,7 @@ impl DepthFirstScheduler {
     /// Searches for candidates from the given course.
     fn get_candidates_from_course(&self, course_ids: &[Ustr]) -> Result<Vec<Candidate>> {
         // Initialize the set of visited units and the stack with the starting lessons from the
-        // courses. Add all starting lessons, even if their dependencies are not satisfied because
+        // courses. Add all starting lessons, even if their dependencies are not satisfied, because
         // the user specifically asked for questions from these courses.
         let mut stack: Vec<StackItem> = Vec::new();
         let mut visited = UstrSet::default();

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -277,7 +277,7 @@ lazy_static! {
             lessons: vec![
                 TestLesson {
                     id: TestId(5, Some(0), None),
-                    dependencies: vec![],
+                    dependencies: vec![TestId(4, Some(1), None)],
                     metadata: BTreeMap::from([
                         (
                             "lesson_key_1".to_string(),


### PR DESCRIPTION
The starting lessons in the courses in the course filter should be added regardless of whether their dependencies are satisfied.