### PR TITLE
Fix bugs when a starting course has no lessons

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -172,6 +172,13 @@ impl InMemoryUnitGraph {
             self.dependency_sinks.remove(unit_id);
         }
 
+        // Remove the unit from the dependency sinks if it's a lesson and its course exists. If the
+        // course is a dependency sink, the lesson is redundant. If the course is not a depencency
+        // sink, the lesson is not a dependency sink either.
+        if let Some(_) = self.get_lesson_course(unit_id) {
+            self.dependency_sinks.remove(unit_id);
+        }
+
         // If a course is mentioned as a dependency, but it's missing, it should be a dependency
         // sink. To ensure this requirement, the function is called recursively on all the
         // dependents with an empty dependency list. It's safe to do this for all courses because a

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -175,7 +175,7 @@ impl InMemoryUnitGraph {
         // Remove the unit from the dependency sinks if it's a lesson and its course exists. If the
         // course is a dependency sink, the lesson is redundant. If the course is not a depencency
         // sink, the lesson is not a dependency sink either.
-        if let Some(_) = self.get_lesson_course(unit_id) {
+        if self.get_lesson_course(unit_id).is_some() {
             self.dependency_sinks.remove(unit_id);
         }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -149,7 +149,6 @@ impl DepthFirstScheduler {
         // Replace any missing units with their dependents and repeat this process until there are
         // no missing courses.
         let mut starting_courses = self.data.unit_graph.read().get_dependency_sinks();
-        println!("dependency sinks: {:?}", starting_courses);
         loop {
             let mut new_starting_courses = UstrSet::default();
             for course_id in &starting_courses {
@@ -209,7 +208,6 @@ impl DepthFirstScheduler {
     fn get_initial_stack(&self, metadata_filter: Option<&MetadataFilter>) -> Vec<StackItem> {
         // First get all the starting units and then all of their starting lessons.
         let starting_units = self.get_all_starting_units();
-        println!("Starting units: {:?}", starting_units);
         let mut initial_stack: Vec<StackItem> = vec![];
         for course_id in starting_units {
             let lesson_ids = self
@@ -376,7 +374,6 @@ impl DepthFirstScheduler {
         // dependencies that are needed to reach all the units in the graph.
         let mut stack: Vec<StackItem> = Vec::new();
         let starting_lessons = self.get_initial_stack(metadata_filter);
-        println!("Starting lessons: {:?}", starting_lessons);
         stack.extend(starting_lessons.into_iter());
 
         // Initialize the list of candidates and the set of visited units.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -149,6 +149,7 @@ impl DepthFirstScheduler {
         // Replace any missing units with their dependents and repeat this process until there are
         // no missing courses.
         let mut starting_courses = self.data.unit_graph.read().get_dependency_sinks();
+        println!("dependency sinks: {:?}", starting_courses);
         loop {
             let mut new_starting_courses = UstrSet::default();
             for course_id in &starting_courses {
@@ -208,6 +209,7 @@ impl DepthFirstScheduler {
     fn get_initial_stack(&self, metadata_filter: Option<&MetadataFilter>) -> Vec<StackItem> {
         // First get all the starting units and then all of their starting lessons.
         let starting_units = self.get_all_starting_units();
+        println!("Starting units: {:?}", starting_units);
         let mut initial_stack: Vec<StackItem> = vec![];
         for course_id in starting_units {
             let lesson_ids = self
@@ -374,6 +376,7 @@ impl DepthFirstScheduler {
         // dependencies that are needed to reach all the units in the graph.
         let mut stack: Vec<StackItem> = Vec::new();
         let starting_lessons = self.get_initial_stack(metadata_filter);
+        println!("Starting lessons: {:?}", starting_lessons);
         stack.extend(starting_lessons.into_iter());
 
         // Initialize the list of candidates and the set of visited units.

--- a/tests/large_tests.rs
+++ b/tests/large_tests.rs
@@ -116,9 +116,9 @@ fn all_exercises_scheduled_random() -> Result<()> {
     let random_library = RandomCourseLibrary {
         num_courses: 25,
         course_dependencies_range: (0, 5),
-        lessons_per_course_range: (1, 5),
+        lessons_per_course_range: (0, 5),
         lesson_dependencies_range: (0, 5),
-        exercises_per_lesson_range: (1, 20),
+        exercises_per_lesson_range: (0, 20),
     }
     .generate_library();
     let mut trane = init_trane(&temp_dir.path().to_path_buf(), &random_library)?;

--- a/tests/large_tests.rs
+++ b/tests/large_tests.rs
@@ -114,7 +114,7 @@ fn all_exercises_scheduled_random() -> Result<()> {
     // Initialize test course library.
     let temp_dir = TempDir::new()?;
     let random_library = RandomCourseLibrary {
-        num_courses: 25,
+        num_courses: 50,
         course_dependencies_range: (0, 5),
         lessons_per_course_range: (0, 5),
         lesson_dependencies_range: (0, 5),
@@ -126,7 +126,7 @@ fn all_exercises_scheduled_random() -> Result<()> {
     // Run the simulation.
     let exercise_ids = all_exercises(&random_library);
     let mut simulation = TraneSimulation::new(
-        exercise_ids.len() * 100,
+        exercise_ids.len() * 50,
         Box::new(|_| Some(MasteryScore::Five)),
     );
     simulation.run_simulation(&mut trane, &vec![], None)?;


### PR DESCRIPTION
The course was being ignored and the entire graph was not being traversed as a result. Instead, add such courses to the initial stack so that its dependents can be traversed.

Also, remove lessons with existing courses from the dependency sinks.