### PR TITLE
Adjust scoring options:

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -522,8 +522,8 @@ pub struct SchedulerOptions {
     /// The minimum average score of a unit required to move on to its dependents.
     pub passing_score: f32,
 
-    /// The maximum number of scores to lookup in the practice stats.
-    pub num_scores: usize,
+    /// The number of trials to retrive from the practice stats to compute an exercise's score.
+    pub num_trials: usize,
 }
 
 impl Default for SchedulerOptions {
@@ -537,18 +537,18 @@ impl Default for SchedulerOptions {
             },
             current_window_opts: MasteryWindow {
                 percentage: 0.5,
-                range: (2.5, 3.8),
+                range: (2.5, 3.75),
             },
             easy_window_opts: MasteryWindow {
                 percentage: 0.2,
-                range: (3.8, 4.7),
+                range: (3.75, 4.7),
             },
             mastered_window_opts: MasteryWindow {
                 percentage: 0.1,
                 range: (4.7, 5.0),
             },
-            passing_score: 3.8,
-            num_scores: 25,
+            passing_score: 3.75,
+            num_trials: 20,
         }
     }
 }

--- a/src/scheduler/cache.rs
+++ b/src/scheduler/cache.rs
@@ -76,7 +76,7 @@ impl ScoreCache {
             .data
             .practice_stats
             .read()
-            .get_scores(exercise_id, self.options.read().num_scores)
+            .get_scores(exercise_id, self.options.read().num_trials)
             .unwrap_or_default();
         let score = self.scorer.score(&scores)?;
         self.exercise_cache.write().insert(*exercise_id, score);

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -21,7 +21,7 @@ const INITIAL_WEIGHT: f32 = 10.0;
 const MIN_WEIGHT: f32 = 1.0;
 
 /// The score of a trial diminishes by the number of days multiplied by this factor.
-const SCORE_ADJUSTMENT_FACTOR: f32 = 0.025;
+const SCORE_ADJUSTMENT_FACTOR: f32 = 0.01;
 
 /// A trait exposing a function to score an exercise based on the results of previous trials.
 pub trait ExerciseScorer {


### PR DESCRIPTION
- Set the default number of trials used to compute the score to 20.
- Set the default passing score to 3.75 and adjust the scoring windows accordingly.
- Set the factor by which scores are reduced with each passing day to 0.01.