### PR TITLE
Remove deny_unknown_fields directive

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -298,7 +298,6 @@ impl GenerateManifests for CourseGenerator {
 
 /// A manifest describing the contents of a course.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct CourseManifest {
     /// The ID assigned to this course.
     ///
@@ -388,7 +387,6 @@ impl GetUnitType for CourseManifest {
 
 /// A manifest describing the contents of a lesson.
 #[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct LessonManifest {
     /// The ID assigned to this lesson.
     ///
@@ -483,7 +481,6 @@ pub enum ExerciseType {
 
 /// The asset storing the material of a particular exercise.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub enum ExerciseAsset {
     /// An asset which stores a link to a SoundSlice.
     SoundSliceAsset {


### PR DESCRIPTION
Initially all manifests had the same name so they could be confused when reading the library. This is no longer the case, so the directive can be removed.