### PR TITLE
Allow flashcard assets to have no back.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trane"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 description = "An automated system for learning complex skills"
 license = "GPL-3.0"

--- a/src/course_builder/knowledge_base_builder.rs
+++ b/src/course_builder/knowledge_base_builder.rs
@@ -200,7 +200,7 @@ mod test {
                 short_lesson_id: "lesson1".into(),
                 course_id: "course1".into(),
                 front_file: "ex1.front.md".to_string(),
-                back_file: "ex1.back.md".to_string(),
+                back_file: Some("ex1.back.md".to_string()),
                 name: Some("Exercise 1".to_string()),
                 description: Some("Exercise 1 description".to_string()),
                 exercise_type: Some(ExerciseType::Procedural),

--- a/src/data.rs
+++ b/src/data.rs
@@ -903,6 +903,28 @@ mod test {
         Ok(())
     }
 
+    /// Verifies the `VerifyPaths` trait works for a flashcard asset.
+    #[test]
+    fn verify_flashcard_assets() -> Result<()> {
+        // Verify a flashcard with no back.
+        let temp_dir = tempfile::tempdir()?;
+        let front_file = tempfile::NamedTempFile::new_in(temp_dir.path())?;
+        let flashcard_asset = ExerciseAsset::FlashcardAsset {
+            front_path: front_file.path().as_os_str().to_str().unwrap().to_string(),
+            back_path: None,
+        };
+        assert!(flashcard_asset.verify_paths(temp_dir.path())?);
+
+        // Verify a flashcard with front and back.
+        let back_file = tempfile::NamedTempFile::new_in(temp_dir.path())?;
+        let flashcard_asset = ExerciseAsset::FlashcardAsset {
+            front_path: front_file.path().as_os_str().to_str().unwrap().to_string(),
+            back_path: Some(back_file.path().as_os_str().to_str().unwrap().to_string()),
+        };
+        assert!(flashcard_asset.verify_paths(temp_dir.path())?);
+        Ok(())
+    }
+
     /// Verifies the `Display` trait for each unit type.
     #[test]
     fn unit_type_display() {

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -171,7 +171,7 @@ impl TestLesson {
                 .exercise_type(ExerciseType::Procedural)
                 .exercise_asset(ExerciseAsset::FlashcardAsset {
                     front_path: "question.md".to_string(),
-                    back_path: "answer.md".to_string(),
+                    back_path: Some("answer.md".to_string()),
                 })
                 .clone(),
             exercise_builders,

--- a/tests/knowledge_base_tests.rs
+++ b/tests/knowledge_base_tests.rs
@@ -57,29 +57,36 @@ fn knowledge_base_builder(
             let exercises = (0..num_exercises_per_lesson)
                 .map(|exercise_index| {
                     let front_path = format!("exercise_{}.front.md", exercise_index);
-                    let back_path = format!("exercise_{}.back.md", exercise_index);
+                    // Let even exercises have a back file and odds have none.
+                    let back_path = if exercise_index % 2 == 0 {
+                        Some(format!("exercise_{}.back.md", exercise_index))
+                    } else {
+                        None
+                    };
 
+                    // Create the asset and exercise builders.
+                    let mut asset_builders = vec![AssetBuilder {
+                        file_name: front_path.clone(),
+                        contents: "Front".into(),
+                    }];
+                    if let Some(back_path) = &back_path {
+                        asset_builders.push(AssetBuilder {
+                            file_name: back_path.clone(),
+                            contents: "Back".into(),
+                        });
+                    }
                     ExerciseBuilder {
                         exercise: KnowledgeBaseExercise {
                             short_id: format!("exercise_{}", exercise_index),
                             short_lesson_id: lesson_id,
                             course_id: course_manifest.id,
-                            front_file: front_path.clone(),
-                            back_file: back_path.clone(),
+                            front_file: front_path,
+                            back_file: back_path,
                             name: None,
                             description: None,
                             exercise_type: None,
                         },
-                        asset_builders: vec![
-                            AssetBuilder {
-                                file_name: front_path,
-                                contents: "Front".into(),
-                            },
-                            AssetBuilder {
-                                file_name: back_path,
-                                contents: "Back".into(),
-                            },
-                        ],
+                        asset_builders,
                     }
                 })
                 .collect();


### PR DESCRIPTION
Some exercises do not really need a back, as they merely reference an external resource, for example.