### PR TITLE
Improve performance due to slow indexing

### DIFF
--- a/src/course_library.rs
+++ b/src/course_library.rs
@@ -550,8 +550,8 @@ impl LocalCourseLibrary {
             reader: None,
         };
 
-        // Initialize the search index writer with an initial arena size of 50 MB.
-        let mut index_writer = library.index.writer(50_000_000)?;
+        // Initialize the search index writer with an initial arena size of 150 MB.
+        let mut index_writer = library.index.writer(150_000_000)?;
 
         // Convert the list of paths to ignore into absolute paths.
         let absolute_root = library_root.canonicalize()?;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -746,10 +746,14 @@ impl DepthFirstScheduler {
             if let Some(superseded_by) = superseded_by {
                 all_superseded_by.extend(superseded_by);
             }
+
             let superseded_by = self.data.get_superseded_by(&candidate.course_id);
             if let Some(superseded_by) = superseded_by {
                 all_superseded_by.extend(superseded_by);
             }
+        }
+        if all_superseded_by.is_empty() {
+            return candidates;
         }
 
         // Filter out the superseding lessons and courses with scores lower than the superseding


### PR DESCRIPTION
Newer versions of tantivy require more memory during the indexing phase. Otherwise the indexing phase will be a lot slower than in previous versions.

See https://github.com/quickwit-oss/tantivy/issues/2156 for details.