### PR TITLE
Superseded units should work recursively

### DIFF
--- a/tests/superseded_tests.rs
+++ b/tests/superseded_tests.rs
@@ -87,6 +87,101 @@ lazy_static! {
                 },
             ],
         },
+        TestCourse {
+            id: TestId(3, None, None),
+            dependencies: vec![],
+            superseded: vec![],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(3, Some(0), None),
+                    dependencies: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(3, Some(1), None),
+                    dependencies: vec![TestId(3, Some(0), None)],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
+        TestCourse {
+            id: TestId(4, None, None),
+            dependencies: vec![TestId(3, None, None)],
+            superseded: vec![TestId(3, None, None)],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(4, Some(0), None),
+                    dependencies: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(4, Some(1), None),
+                    dependencies: vec![TestId(4, Some(0), None)],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
+        TestCourse {
+            id: TestId(5, None, None),
+            dependencies: vec![TestId(4, None, None)],
+            superseded: vec![TestId(4, None, None)],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(5, Some(0), None),
+                    dependencies: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(5, Some(1), None),
+                    dependencies: vec![TestId(5, Some(0), None)],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
+        TestCourse {
+            id: TestId(6, None, None),
+            dependencies: vec![],
+            superseded: vec![],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(6, Some(0), None),
+                    dependencies: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(6, Some(1), None),
+                    dependencies: vec![TestId(6, Some(0), None)],
+                    superseded: vec![TestId(6, Some(0), None)],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(6, Some(2), None),
+                    dependencies: vec![TestId(6, Some(1), None)],
+                    superseded: vec![TestId(6, Some(1), None)],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
     ];
 }
 
@@ -99,7 +194,7 @@ fn scheduler_respects_superseded_courses() -> Result<()> {
 
     // Run the simulation first giving a score of 5 to all exercises.
     let superseded_course_id = TestId(0, None, None);
-    let mut simulation = TraneSimulation::new(500, Box::new(|_| Some(MasteryScore::Five)));
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
     simulation.run_simulation(&mut trane, &vec![], None)?;
 
     // Every exercise should be in `simulation.answer_history`.
@@ -115,7 +210,7 @@ fn scheduler_respects_superseded_courses() -> Result<()> {
     }
 
     // Run the simulation again to clear the simulation history.
-    let mut simulation = TraneSimulation::new(500, Box::new(|_| Some(MasteryScore::Five)));
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
     simulation.run_simulation(&mut trane, &vec![], None)?;
 
     // None of the exercises in the superseded course should have been scheduled.
@@ -168,7 +263,7 @@ fn scheduler_respects_superseded_lessons() -> Result<()> {
 
     // Run the simulation first giving a score of 5 to all exercises.
     let superseded_lesson_id = TestId(2, Some(0), None);
-    let mut simulation = TraneSimulation::new(500, Box::new(|_| Some(MasteryScore::Five)));
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
     simulation.run_simulation(&mut trane, &vec![], None)?;
 
     // Every exercise should be in `simulation.answer_history`.
@@ -184,7 +279,7 @@ fn scheduler_respects_superseded_lessons() -> Result<()> {
     }
 
     // Run the simulation again to clear the simulation history.
-    let mut simulation = TraneSimulation::new(500, Box::new(|_| Some(MasteryScore::Five)));
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
     simulation.run_simulation(&mut trane, &vec![], None)?;
 
     // None of the exercises in the superseded lesson should have been scheduled.
@@ -217,6 +312,220 @@ fn scheduler_respects_superseded_lessons() -> Result<()> {
     for exercise_id in &exercise_ids {
         let exercise_ustr = exercise_id.to_ustr();
         if exercise_id.exercise_in_course(&superseded_lesson_id) {
+            assert!(
+                simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should have been scheduled",
+                exercise_id
+            );
+            assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+        }
+    }
+    Ok(())
+}
+
+/// Verifies that the superseded courses are dealt with correctly during scheduling when the
+/// superseding course is superseded by another unit.
+#[test]
+fn scheduler_respects_superseded_course_chain() -> Result<()> {
+    // Initialize test course library.
+    let temp_dir = TempDir::new()?;
+    let mut trane = init_test_simulation(&temp_dir.path(), &LIBRARY)?;
+
+    // Run the simulation first giving a score of 5 to all exercises.
+    let superseded_course_ids = [TestId(3, None, None), TestId(4, None, None)];
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // Every exercise should be in `simulation.answer_history`.
+    let exercise_ids = all_test_exercises(&LIBRARY);
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        assert!(
+            simulation.answer_history.contains_key(&exercise_ustr),
+            "exercise {:?} should have been scheduled",
+            exercise_id
+        );
+        assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+    }
+
+    // Run the simulation again to clear the simulation history.
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // None of the exercises in the superseded courses should have been scheduled.
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if superseded_course_ids
+            .iter()
+            .any(|id| exercise_id.exercise_in_course(id))
+        {
+            assert!(
+                !simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should not have been scheduled",
+                exercise_id
+            );
+        }
+    }
+
+    // Run the simulation again, but this time give a score of 1 to all exercises in the superseding
+    // course at the end of the chain.
+    let mut simulation = TraneSimulation::new(
+        1000,
+        Box::new(|id| {
+            if id.starts_with("5::") {
+                Some(MasteryScore::One)
+            } else {
+                Some(MasteryScore::Five)
+            }
+        }),
+    );
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // This time around, all the exercises in the second superseded course should have been
+    // scheduled. The exercises in the first superseded course should not have been scheduled.
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if exercise_id.exercise_in_course(&superseded_course_ids[1]) {
+            assert!(
+                simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should have been scheduled",
+                exercise_id
+            );
+            assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+        } else if exercise_id.exercise_in_course(&superseded_course_ids[0]) {
+            assert!(
+                !simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should not have been scheduled",
+                exercise_id
+            );
+        }
+    }
+
+    // Run the simulation again, but this time give a score of 1 to all exercises in both
+    // superseding courses.
+    let mut simulation = TraneSimulation::new(
+        1000,
+        Box::new(|id| {
+            if id.starts_with("4::") || id.starts_with("5::") {
+                Some(MasteryScore::One)
+            } else {
+                Some(MasteryScore::Five)
+            }
+        }),
+    );
+
+    // This time around all exercises in the first superseded course should have been scheduled.
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if exercise_id.exercise_in_course(&superseded_course_ids[0]) {
+            assert!(
+                simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should have been scheduled",
+                exercise_id
+            );
+            assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+        }
+    }
+    Ok(())
+}
+
+/// Verifies that the superseded lessons are dealt with correctly during scheduling when the
+/// superseding lesson is superseded by another unit.
+#[test]
+fn scheduler_respects_superseded_lesson_chain() -> Result<()> {
+    // Initialize test course library.
+    let temp_dir = TempDir::new()?;
+    let mut trane = init_test_simulation(&temp_dir.path(), &LIBRARY)?;
+
+    // Run the simulation first giving a score of 5 to all exercises.
+    let superseded_lesson_ids = [TestId(6, Some(0), None), TestId(6, Some(1), None)];
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // Every exercise should be in `simulation.answer_history`.
+    let exercise_ids = all_test_exercises(&LIBRARY);
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        assert!(
+            simulation.answer_history.contains_key(&exercise_ustr),
+            "exercise {:?} should have been scheduled",
+            exercise_id
+        );
+        assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+    }
+
+    // Run the simulation again to clear the simulation history.
+    let mut simulation = TraneSimulation::new(1000, Box::new(|_| Some(MasteryScore::Five)));
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // None of the exercises in the superseded lessons should have been scheduled.
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if superseded_lesson_ids
+            .iter()
+            .any(|id| exercise_id.exercise_in_lesson(id))
+        {
+            assert!(
+                !simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should not have been scheduled",
+                exercise_id
+            );
+        }
+    }
+
+    // Run the simulation again, but this time give a score of 1 to all exercises in the superseding
+    // lesson at the end of the chain.
+    let mut simulation = TraneSimulation::new(
+        1000,
+        Box::new(|id| {
+            if id.starts_with("6::2::") {
+                Some(MasteryScore::One)
+            } else {
+                Some(MasteryScore::Five)
+            }
+        }),
+    );
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+
+    // This time around, all the exercises in the second superseded lesson should have been
+    // scheduled. The exercises in the first superseded lesson should not have been scheduled.
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if exercise_id.exercise_in_lesson(&superseded_lesson_ids[1]) {
+            assert!(
+                simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should have been scheduled",
+                exercise_id
+            );
+            assert_simulation_scores(&exercise_ustr, &trane, &simulation.answer_history)?;
+        } else if exercise_id.exercise_in_lesson(&superseded_lesson_ids[0]) {
+            assert!(
+                !simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should not have been scheduled",
+                exercise_id
+            );
+        }
+    }
+
+    // Run the simulation again, but this time give a score of 1 to all exercises in both
+    // superseding lessons.
+    let mut simulation = TraneSimulation::new(
+        1000,
+        Box::new(|id| {
+            if id.starts_with("6::1") || id.starts_with("6::2") {
+                Some(MasteryScore::One)
+            } else {
+                Some(MasteryScore::Five)
+            }
+        }),
+    );
+
+    // This time around all exercises in the first superseded lesson should have been scheduled.
+    simulation.run_simulation(&mut trane, &vec![], None)?;
+    for exercise_id in &exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if exercise_id.exercise_in_lesson(&superseded_lesson_ids[0]) {
             assert!(
                 simulation.answer_history.contains_key(&exercise_ustr),
                 "exercise {:?} should have been scheduled",


### PR DESCRIPTION
If unit A is superseded by unit B and unit B is in turn superseded by unit C, then unit A should be considered to be superseded by unit C when unit B is superseded by unit C.