### PR TITLE
Consistent naming of local trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trane"
-version = "0.19.2"
+version = "0.20.0"
 edition = "2021"
 description = "An automated system for learning complex skills"
 license = "AGPL-3.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,10 +30,10 @@ pub struct TraneFFI {
 }
 
 impl TraneFFI {
-    /// Creates and wraps a new instance of Trane for use with FFI.
-    pub fn new(working_dir: &Path, library_root: &Path) -> Result<TraneFFI> {
+    /// Creates and wraps a new local instance of Trane for use with FFI.
+    pub fn new_local(working_dir: &Path, library_root: &Path) -> Result<TraneFFI> {
         Ok(TraneFFI {
-            trane: Trane::new(working_dir, library_root)?,
+            trane: Trane::new_local(working_dir, library_root)?,
         })
     }
 }

--- a/src/practice_stats.rs
+++ b/src/practice_stats.rs
@@ -47,12 +47,12 @@ pub trait PracticeStats {
 }
 
 /// An implementation of [`PracticeStats`] backed by `SQLite`.
-pub struct PracticeStatsDB {
+pub struct LocalPracticeStats {
     /// A pool of connections to the database.
     pool: Pool<SqliteConnectionManager>,
 }
 
-impl PracticeStatsDB {
+impl LocalPracticeStats {
     /// Returns all the migrations needed to set up the database.
     fn migrations() -> Migrations<'static> {
         Migrations::new(vec![
@@ -98,16 +98,16 @@ impl PracticeStatsDB {
     }
 
     /// A constructor taking a `SQLite` connection manager.
-    fn new(connection_manager: SqliteConnectionManager) -> Result<PracticeStatsDB> {
+    fn new(connection_manager: SqliteConnectionManager) -> Result<LocalPracticeStats> {
         // Create a connection pool and initialize the database.
         let pool = Pool::new(connection_manager)?;
-        let mut stats = PracticeStatsDB { pool };
+        let mut stats = LocalPracticeStats { pool };
         stats.init()?;
         Ok(stats)
     }
 
     /// A constructor taking the path to a database file.
-    pub fn new_from_disk(db_path: &str) -> Result<PracticeStatsDB> {
+    pub fn new_from_disk(db_path: &str) -> Result<LocalPracticeStats> {
         Self::new(db_utils::new_connection_manager(db_path))
     }
 
@@ -213,7 +213,7 @@ impl PracticeStatsDB {
     }
 }
 
-impl PracticeStats for PracticeStatsDB {
+impl PracticeStats for LocalPracticeStats {
     fn get_scores(
         &self,
         exercise_id: Ustr,
@@ -252,12 +252,12 @@ mod test {
 
     use crate::{
         data::{ExerciseTrial, MasteryScore},
-        practice_stats::{PracticeStats, PracticeStatsDB},
+        practice_stats::{LocalPracticeStats, PracticeStats},
     };
 
     fn new_tests_stats() -> Result<Box<dyn PracticeStats>> {
         let connection_manager = SqliteConnectionManager::memory();
-        let practice_stats = PracticeStatsDB::new(connection_manager)?;
+        let practice_stats = LocalPracticeStats::new(connection_manager)?;
         Ok(Box::new(practice_stats))
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -35,9 +35,6 @@ use crate::{
         ExerciseManifest, MasteryScore, SchedulerOptions, UnitType,
     },
     error::ExerciseSchedulerError,
-    graph::UnitGraph,
-    practice_stats::PracticeStats,
-    review_list::ReviewList,
     scheduler::{cache::ScoreCache, data::SchedulerData, filter::CandidateFilter},
 };
 

--- a/src/scheduler/cache.rs
+++ b/src/scheduler/cache.rs
@@ -11,10 +11,7 @@ use std::cell::RefCell;
 use ustr::{Ustr, UstrMap, UstrSet};
 
 use crate::{
-    blacklist::Blacklist,
     data::{SchedulerOptions, UnitType},
-    graph::UnitGraph,
-    practice_stats::PracticeStats,
     scheduler::SchedulerData,
     scorer::{ExerciseScorer, SimpleScorer},
 };

--- a/src/scheduler/data.rs
+++ b/src/scheduler/data.rs
@@ -7,16 +7,16 @@ use std::sync::Arc;
 use ustr::{Ustr, UstrMap, UstrSet};
 
 use crate::{
-    blacklist::{Blacklist, BlacklistDB},
-    course_library::{CourseLibrary, LocalCourseLibrary},
+    blacklist::Blacklist,
+    course_library::CourseLibrary,
     data::{
         filter::{KeyValueFilter, SavedFilter, SessionPart, StudySessionData, UnitFilter},
         CourseManifest, ExerciseManifest, LessonManifest, SchedulerOptions, UnitType,
     },
-    filter_manager::{FilterManager, LocalFilterManager},
-    graph::{InMemoryUnitGraph, UnitGraph},
-    practice_stats::PracticeStatsDB,
-    review_list::ReviewListDB,
+    filter_manager::FilterManager,
+    graph::UnitGraph,
+    practice_stats::PracticeStats,
+    review_list::ReviewList,
 };
 
 /// A struct encapsulating all the state needed by the scheduler.
@@ -26,22 +26,22 @@ pub struct SchedulerData {
     pub options: SchedulerOptions,
 
     /// The course library storing manifests and info about units.
-    pub course_library: Arc<RwLock<LocalCourseLibrary>>,
+    pub course_library: Arc<RwLock<dyn CourseLibrary>>,
 
     /// The dependency graph of courses and lessons.
-    pub unit_graph: Arc<RwLock<InMemoryUnitGraph>>,
+    pub unit_graph: Arc<RwLock<dyn UnitGraph>>,
 
     /// The list of previous exercise results.
-    pub practice_stats: Arc<RwLock<PracticeStatsDB>>,
+    pub practice_stats: Arc<RwLock<dyn PracticeStats>>,
 
     /// The list of units to skip during scheduling.
-    pub blacklist: Arc<RwLock<BlacklistDB>>,
+    pub blacklist: Arc<RwLock<dyn Blacklist>>,
 
     /// The list of units which should be reviewed by the student.
-    pub review_list: Arc<RwLock<ReviewListDB>>,
+    pub review_list: Arc<RwLock<dyn ReviewList>>,
 
     /// The manager used to access unit filters saved by the user.
-    pub filter_manager: Arc<RwLock<LocalFilterManager>>,
+    pub filter_manager: Arc<RwLock<dyn FilterManager>>,
 
     /// A map storing the number of times an exercise has been scheduled during the lifetime of this
     /// scheduler. The value is used to give more weight during filtering to exercises that have
@@ -378,7 +378,6 @@ mod test {
     use ustr::Ustr;
 
     use crate::{
-        blacklist::Blacklist,
         data::{
             filter::{
                 FilterType, KeyValueFilter, SavedFilter, SessionPart, StudySession,

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -509,7 +509,7 @@ pub fn init_simulation(
     }
 
     // Initialize the Trane library.
-    let trane = Trane::new(library_root, library_root)?;
+    let trane = Trane::new_local(library_root, library_root)?;
     Ok(trane)
 }
 
@@ -523,7 +523,7 @@ pub fn init_test_simulation(library_root: &Path, courses: &Vec<TestCourse>) -> R
         .collect::<Result<()>>()?;
 
     // Initialize the Trane library.
-    let trane = Trane::new(library_root, library_root)?;
+    let trane = Trane::new_local(library_root, library_root)?;
     Ok(trane)
 }
 

--- a/tests/knowledge_base_tests.rs
+++ b/tests/knowledge_base_tests.rs
@@ -134,7 +134,7 @@ fn init_knowledge_base_simulation(
         .collect::<Result<()>>()?;
 
     // Initialize the Trane library.
-    let trane = Trane::new(library_root, library_root)?;
+    let trane = Trane::new_local(library_root, library_root)?;
     Ok(trane)
 }
 


### PR DESCRIPTION
Call them LocalBlacklist, etc., in contrast to possible remote implementations.

Use dynamic dispatch in SchedulerData instead of implementations. No significant performance degradation observed in actual testing.