### PR TITLE
Modify transcription exercises to include external link

### DIFF
--- a/ffi/trane.ts
+++ b/ffi/trane.ts
@@ -153,16 +153,20 @@ export enum ExerciseType {
 }
 
 export type ExerciseAsset = 
+	| { type: "BasicAsset", content: BasicAsset }
+	| { type: "FlashcardAsset", content: {
+	front_path: string;
+	back_path?: string;
+}}
 	| { type: "SoundSliceAsset", content: {
 	link: string;
 	description?: string;
 	backup?: string;
 }}
-	| { type: "FlashcardAsset", content: {
-	front_path: string;
-	back_path?: string;
-}}
-	| { type: "BasicAsset", content: BasicAsset };
+	| { type: "TranscriptionAsset", content: {
+	content?: string;
+	external_link?: TranscriptionLink;
+}};
 
 export interface ExerciseManifest {
 	id: string;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1149,6 +1149,27 @@ mod test {
         Ok(())
     }
 
+    /// Verifies the `NormalizePaths` trait works for a transcription asset.
+    #[test]
+    fn transcription_normalize_paths() {
+        let asset = ExerciseAsset::TranscriptionAsset {
+            content: "content".into(),
+            external_link: None,
+        };
+        assert!(asset.normalize_paths(Path::new("./")).is_ok());
+    }
+
+    /// Verifies the `VerifyPaths` trait works for a transcription asset.
+    #[test]
+    fn transcription_verify_paths() -> Result<()> {
+        let asset = ExerciseAsset::TranscriptionAsset {
+            content: "content".into(),
+            external_link: None,
+        };
+        assert!(asset.verify_paths(Path::new("./"))?);
+        Ok(())
+    }
+
     /// Verifies the `VerifyPaths` trait works for a flashcard asset.
     #[test]
     fn verify_flashcard_assets() -> Result<()> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -384,11 +384,11 @@ impl VerifyPaths for CourseManifest {
     fn verify_paths(&self, working_dir: &Path) -> Result<bool> {
         // The paths mentioned in the instructions and material must both exist.
         let instructions_exist = match &self.course_instructions {
-            None => true,
+            None => true, // grcov-excl-line
             Some(asset) => asset.verify_paths(working_dir)?,
         };
         let material_exists = match &self.course_material {
-            None => true,
+            None => true, // grcov-excl-line
             Some(asset) => asset.verify_paths(working_dir)?,
         };
         Ok(instructions_exist && material_exists)
@@ -465,13 +465,11 @@ pub struct LessonManifest {
 impl NormalizePaths for LessonManifest {
     fn normalize_paths(&self, working_dir: &Path) -> Result<Self> {
         let mut clone = self.clone();
-        match &self.lesson_instructions {
-            None => (),
-            Some(asset) => clone.lesson_instructions = Some(asset.normalize_paths(working_dir)?),
+        if let Some(asset) = &self.lesson_instructions {
+            clone.lesson_instructions = Some(asset.normalize_paths(working_dir)?);
         }
-        match &self.lesson_material {
-            None => (),
-            Some(asset) => clone.lesson_material = Some(asset.normalize_paths(working_dir)?),
+        if let Some(asset) = &self.lesson_material {
+            clone.lesson_material = Some(asset.normalize_paths(working_dir)?);
         }
         Ok(clone)
     }
@@ -481,11 +479,11 @@ impl VerifyPaths for LessonManifest {
     fn verify_paths(&self, working_dir: &Path) -> Result<bool> {
         // The paths mentioned in the instructions and material must both exist.
         let instruction_exists = match &self.lesson_instructions {
-            None => true,
+            None => true, // grcov-excl-line
             Some(asset) => asset.verify_paths(working_dir)?,
         };
         let material_exists = match &self.lesson_material {
-            None => true,
+            None => true, // grcov-excl-line
             Some(asset) => asset.verify_paths(working_dir)?,
         };
         Ok(instruction_exists && material_exists)
@@ -1055,28 +1053,6 @@ mod test {
                 .unwrap()
                 .get_unit_type()
         );
-    }
-
-    /// Verifies that checking the paths of a manifest works if there are no paths to check.
-    #[test]
-    fn verify_paths_none() -> Result<()> {
-        let lesson_manifest = LessonManifestBuilder::default()
-            .id("test")
-            .course_id("test")
-            .name("Test".to_string())
-            .dependencies(vec![])
-            .build()
-            .unwrap();
-        lesson_manifest.verify_paths(Path::new("./"))?;
-
-        let course_manifest = CourseManifestBuilder::default()
-            .id("test")
-            .name("Test".to_string())
-            .dependencies(vec![])
-            .build()
-            .unwrap();
-        course_manifest.verify_paths(Path::new("./"))?;
-        Ok(())
     }
 
     /// Verifies the `NormalizePaths` trait works for a `SoundSlice` asset.

--- a/src/data/course_generator/transcription.rs
+++ b/src/data/course_generator/transcription.rs
@@ -128,7 +128,7 @@ impl TranscriptionPassages {
                 external_link,
                 duration,
                 ..
-            } => ExerciseAsset::BasicAsset(BasicAsset::InlinedUniqueAsset {
+            } => ExerciseAsset::TranscriptionAsset {
                 content: formatdoc! {"
                     {}
 
@@ -144,9 +144,9 @@ impl TranscriptionPassages {
                     album_name.as_deref().unwrap_or(""), duration.as_deref().unwrap_or(""),
                     external_link.as_ref().map_or("", |l| l.url()), start, end,
                     instrument_instruction
-                }
-                .into(),
-            }),
+                },
+                external_link: external_link.clone(),
+            },
         }
     }
 }
@@ -950,7 +950,7 @@ mod test {
         };
         let exercise_asset =
             passages.generate_exercise_asset("My description", "0:00", "0:01", Some(&instrument));
-        let expected_asset = ExerciseAsset::BasicAsset(BasicAsset::InlinedUniqueAsset {
+        let expected_asset = ExerciseAsset::TranscriptionAsset {
             content: indoc! {"
                 My description
 
@@ -965,13 +965,14 @@ mod test {
                 Transcribe the passage using the instrument: Piano.
             "}
             .into(),
-        });
+            external_link: Some(TranscriptionLink::YouTube("https://example.com".into())),
+        };
         assert_eq!(exercise_asset, expected_asset);
 
         // Generate the asset when an instrument is not specified.
         let exercise_asset =
             passages.generate_exercise_asset("My description", "0:00", "0:01", None);
-        let expected_asset = ExerciseAsset::BasicAsset(BasicAsset::InlinedUniqueAsset {
+        let expected_asset = ExerciseAsset::TranscriptionAsset {
             content: indoc! {"
                 My description
 
@@ -984,7 +985,8 @@ mod test {
                     - Passage interval: 0:00 - 0:01
             "}
             .into(),
-        });
+            external_link: Some(TranscriptionLink::YouTube("https://example.com".into())),
+        };
         assert_eq!(exercise_asset, expected_asset);
     }
 

--- a/src/data/ffi.rs
+++ b/src/data/ffi.rs
@@ -346,6 +346,12 @@ impl From<data::ExerciseType> for ExerciseType {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", content = "content")]
 pub enum ExerciseAsset {
+    BasicAsset(BasicAsset),
+    FlashcardAsset {
+        front_path: String,
+        #[serde(default)]
+        back_path: Option<String>,
+    },
     SoundSliceAsset {
         link: String,
         #[serde(default)]
@@ -353,17 +359,25 @@ pub enum ExerciseAsset {
         #[serde(default)]
         backup: Option<String>,
     },
-    FlashcardAsset {
-        front_path: String,
+    TranscriptionAsset {
         #[serde(default)]
-        back_path: Option<String>,
+        content: String,
+        #[serde(default)]
+        external_link: Option<TranscriptionLink>,
     },
-    BasicAsset(BasicAsset),
 }
 
 impl From<ExerciseAsset> for data::ExerciseAsset {
     fn from(asset: ExerciseAsset) -> Self {
         match asset {
+            ExerciseAsset::BasicAsset(asset) => Self::BasicAsset(asset.into()),
+            ExerciseAsset::FlashcardAsset {
+                front_path,
+                back_path,
+            } => Self::FlashcardAsset {
+                front_path,
+                back_path,
+            },
             ExerciseAsset::SoundSliceAsset {
                 link,
                 description,
@@ -373,14 +387,13 @@ impl From<ExerciseAsset> for data::ExerciseAsset {
                 description,
                 backup,
             },
-            ExerciseAsset::FlashcardAsset {
-                front_path,
-                back_path,
-            } => Self::FlashcardAsset {
-                front_path,
-                back_path,
+            ExerciseAsset::TranscriptionAsset {
+                content,
+                external_link,
+            } => Self::TranscriptionAsset {
+                content,
+                external_link: external_link.map(std::convert::Into::into),
             },
-            ExerciseAsset::BasicAsset(asset) => Self::BasicAsset(asset.into()),
         }
     }
 }
@@ -388,6 +401,14 @@ impl From<ExerciseAsset> for data::ExerciseAsset {
 impl From<data::ExerciseAsset> for ExerciseAsset {
     fn from(asset: data::ExerciseAsset) -> Self {
         match asset {
+            data::ExerciseAsset::BasicAsset(asset) => Self::BasicAsset(asset.into()),
+            data::ExerciseAsset::FlashcardAsset {
+                front_path,
+                back_path,
+            } => Self::FlashcardAsset {
+                front_path,
+                back_path,
+            },
             data::ExerciseAsset::SoundSliceAsset {
                 link,
                 description,
@@ -397,14 +418,13 @@ impl From<data::ExerciseAsset> for ExerciseAsset {
                 description,
                 backup,
             },
-            data::ExerciseAsset::FlashcardAsset {
-                front_path,
-                back_path,
-            } => Self::FlashcardAsset {
-                front_path,
-                back_path,
+            data::ExerciseAsset::TranscriptionAsset {
+                content,
+                external_link,
+            } => Self::TranscriptionAsset {
+                content,
+                external_link: external_link.map(std::convert::Into::into),
             },
-            data::ExerciseAsset::BasicAsset(asset) => Self::BasicAsset(asset.into()),
         }
     }
 }


### PR DESCRIPTION
The raw external link needs to be associated with each exercise to more easily download the audio for the exercise.