### PR TITLE
Skip serialization of most default fields

### DIFF
--- a/src/course_builder/knowledge_base_builder.rs
+++ b/src/course_builder/knowledge_base_builder.rs
@@ -196,6 +196,7 @@ pub struct SimpleKnowledgeBaseExercise {
 
     /// The optional content of the back of the card. If the list is empty, no file will be created.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub back: Vec<String>,
 }
 
@@ -270,10 +271,12 @@ pub struct SimpleKnowledgeBaseLesson {
 
     /// The optional metadata for the lesson.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<BTreeMap<String, Vec<String>>>,
 
     /// A list of additional files to write in the lesson directory.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub additional_files: Vec<AssetBuilder>,
 }
 //>@simple-knowledge-base-lesson

--- a/src/data.rs
+++ b/src/data.rs
@@ -326,11 +326,13 @@ pub struct CourseManifest {
     /// An optional description of the course.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// An optional list of the course's authors.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authors: Option<Vec<String>>,
 
     //@<lp-example-5
@@ -342,17 +344,20 @@ pub struct CourseManifest {
     /// might want to only focus on guitar scales or ear training.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<BTreeMap<String, Vec<String>>>,
 
     //>@lp-example-5
     /// An optional asset, which presents the material covered in the course.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub course_material: Option<BasicAsset>,
 
     /// An optional asset, which presents instructions common to all exercises in the course.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub course_instructions: Option<BasicAsset>,
 
     /// An optional configuration to generate material for this course. Generated courses allow
@@ -360,6 +365,7 @@ pub struct CourseManifest {
     /// all the files a normal course would need.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub generator_config: Option<CourseGenerator>,
 }
 
@@ -442,6 +448,7 @@ pub struct LessonManifest {
     /// An optional description of the lesson.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     //// A mapping of String keys to a list of String values. For example, ("key", ["C"]) could
@@ -449,16 +456,19 @@ pub struct LessonManifest {
     /// stored in the course manifest but allows finer control over which lessons are selected.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<BTreeMap<String, Vec<String>>>,
 
     /// An optional asset, which presents the material covered in the lesson.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lesson_material: Option<BasicAsset>,
 
     /// An optional asset, which presents instructions common to all exercises in the lesson.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lesson_instructions: Option<BasicAsset>,
 }
 
@@ -533,6 +543,7 @@ pub enum ExerciseAsset {
         /// open-ended, or it is referring to an external resource which contains the exercise and
         /// possibly the answer.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         back_path: Option<String>,
     },
 
@@ -545,10 +556,12 @@ pub enum ExerciseAsset {
         /// slice in the key of D Major" or "Practice measures 1 through 4". A missing description
         /// implies the entire slice should be practiced as is.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
 
         /// An optional path to a MusicXML file containing the sheet music for the exercise.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         backup: Option<String>,
     },
 
@@ -561,6 +574,7 @@ pub enum ExerciseAsset {
 
         /// An optional link to the audio for the exercise.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         external_link: Option<TranscriptionLink>,
     },
 }
@@ -664,6 +678,7 @@ pub struct ExerciseManifest {
     /// An optional description of the exercise.
     #[builder(default)]
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// The type of knowledge the exercise tests.
@@ -965,16 +980,19 @@ pub struct RepositoryMetadata {
 pub struct UserPreferences {
     /// The preferences for generating transcription courses.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transcription: Option<TranscriptionPreferences>,
 
     /// The preferences for customizing the behavior of the scheduler.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheduler: Option<SchedulerPreferences>,
 
     /// The paths to ignore when opening the course library. The paths are relative to the
     /// repository root. All child paths are also ignored. For example, adding the directory
     /// "foo/bar" will ignore any courses in "foo/bar" or any of its subdirectories.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignored_paths: Vec<String>,
 }
 //>@user-preferences

--- a/src/data/course_generator/transcription.rs
+++ b/src/data/course_generator/transcription.rs
@@ -59,18 +59,22 @@ pub enum TranscriptionAsset {
 
         /// The name of the artist(s) who performs the track.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         artist_name: Option<String>,
 
         /// The name of the album in which the track appears.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         album_name: Option<String>,
 
         /// The duration of the track.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<String>,
 
         /// A link to an external copy (e.g., YouTube link) of the track.
         #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         external_link: Option<TranscriptionLink>,
     },
 }
@@ -100,6 +104,7 @@ pub struct TranscriptionPassages {
     /// If the map is empty, one passage is assumed to cover the entire asset and the ID for the
     /// exercises will not include a passage ID.
     #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub intervals: HashMap<usize, (String, String)>,
 }
 //>@transcription-passages
@@ -174,12 +179,14 @@ pub struct TranscriptionPreferences {
     /// A path used to download transcription assets to the local filesystem. If not specified,
     /// assets cannot be downloaded.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub download_path: Option<String>,
 
     /// An alias for the download path. This is useful when the download path is a long path or it's
     /// accessible from multiple locations (e.g., Windows and a terminal running on the WSL). Only
     /// used to present the download path to the user.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub download_path_alias: Option<String>,
 }
 //>@transcription-preferences
@@ -199,6 +206,7 @@ pub struct TranscriptionConfig {
     /// The directory can be written relative to the root of the course or as an absolute path. The
     /// first option is recommended. An empty value will safely default to not reading any files.
     #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub passage_directory: String,
 
     /// A list of passages to include in the course in addition to the ones in the passage


### PR DESCRIPTION
Keep serialization of those that are important and will more likely need to be filled.