### PR TITLE
Improve how weight is compute during filtering step

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -135,24 +135,18 @@ struct Candidate {
     /// The score assigned to the exercise represented as a float number between 0.0 and 5.0.
     exercise_score: f32,
 
-    /// The score assigned to the lesson represented as a float number between 0.0 and 5.0.
-    lesson_score: f32,
-
-    /// The score assigned to the course represented as a float number between 0.0 and 5.0.
-    course_score: f32,
-
     /// The number of previous trials that have been recorded for this exercise.
     num_trials: usize,
-
-    /// The number of days since the last trial for this exercise.
-    last_seen: f32,
 
     /// The number of times this exercise has been scheduled during the run of this scheduler.
     frequency: usize,
 
+    /// The urgency of this exercise.
+    urgency: f32,
+
     /// The velocity of learning for this exercise, measuring how quickly the score is improving or
     /// worsening over trials.
-    score_velocity: Option<f32>,
+    velocity: Option<f32>,
 
     /// Whether this candidate comes from a lesson where the search stopped because the lesson's
     /// average score is still below the passing score.
@@ -368,14 +362,6 @@ impl DepthFirstScheduler {
 
         // Generate a list of candidates from the lesson's exercises.
         let course_id = self.data.get_course_id(item.unit_id).unwrap_or_default();
-        let course_score = self
-            .unit_scorer
-            .get_unit_score(course_id)?
-            .unwrap_or_default();
-        let lesson_score = self
-            .unit_scorer
-            .get_unit_score(item.unit_id)?
-            .unwrap_or_default();
         let frequency_map = self.data.frequency_map.read();
         let candidates = exercises
             .into_iter()
@@ -389,17 +375,12 @@ impl DepthFirstScheduler {
                         .unit_scorer
                         .get_unit_score(exercise_id)?
                         .unwrap_or_default(),
-                    course_score,
-                    lesson_score,
                     num_trials: self
                         .unit_scorer
                         .get_exercise_num_trials(exercise_id)?
                         .unwrap_or_default(),
-                    last_seen: self
-                        .unit_scorer
-                        .get_last_seen_days(exercise_id)?
-                        .unwrap_or_default(),
-                    score_velocity: self.unit_scorer.get_exercise_velocity(exercise_id)?,
+                    urgency: self.unit_scorer.get_exercise_urgency(exercise_id)?,
+                    velocity: self.unit_scorer.get_exercise_velocity(exercise_id)?,
                     frequency: frequency_map.get(&exercise_id).copied().unwrap_or(0),
                     dead_end: false,
                     num_dependents: self.data.get_num_dependents(item.unit_id, course_id),
@@ -974,23 +955,12 @@ impl DepthFirstScheduler {
                             .unit_scorer
                             .get_unit_score(unit_id)?
                             .unwrap_or_default(),
-                        lesson_score: self
-                            .unit_scorer
-                            .get_unit_score(lesson_id)?
-                            .unwrap_or_default(),
-                        course_score: self
-                            .unit_scorer
-                            .get_unit_score(course_id)?
-                            .unwrap_or_default(),
                         num_trials: self
                             .unit_scorer
                             .get_exercise_num_trials(unit_id)?
                             .unwrap_or_default(),
-                        last_seen: self
-                            .unit_scorer
-                            .get_last_seen_days(unit_id)?
-                            .unwrap_or_default(),
-                        score_velocity: self.unit_scorer.get_exercise_velocity(unit_id)?,
+                        urgency: self.unit_scorer.get_exercise_urgency(unit_id)?,
+                        velocity: self.unit_scorer.get_exercise_velocity(unit_id)?,
                         frequency: *frequency_map.get(&unit_id).unwrap_or(&0),
                         dead_end: false,
                         num_dependents: self.data.get_num_dependents(lesson_id, course_id),
@@ -1234,7 +1204,7 @@ mod test {
     use super::*;
 
     /// Returns a candidate with the given parameters.
-    fn candidate(id: u32, lesson_score: f32, exercise_score: f32, depth: f32) -> Candidate {
+    fn candidate(id: u32, exercise_score: f32, depth: f32) -> Candidate {
         let exercise_id = format!("exercise-{id}");
         Candidate {
             exercise_id: Ustr::from(exercise_id.as_str()),
@@ -1242,7 +1212,6 @@ mod test {
             course_id: Ustr::from("course"),
             depth,
             exercise_score,
-            lesson_score,
             ..Default::default()
         }
     }
@@ -1254,7 +1223,7 @@ mod test {
         options: PassingScoreOptions,
     ) -> Vec<Candidate> {
         let candidates = (0..num_candidates)
-            .map(|idx| candidate(idx as u32, lesson_score, 0.0, 1.0))
+            .map(|idx| candidate(idx as u32, 0.0, 1.0))
             .collect::<Vec<_>>();
         DepthFirstScheduler::select_candidates(candidates, lesson_score, &options)
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -135,9 +135,6 @@ struct Candidate {
     /// The score assigned to the exercise represented as a float number between 0.0 and 5.0.
     exercise_score: f32,
 
-    /// The number of previous trials that have been recorded for this exercise.
-    num_trials: usize,
-
     /// The number of times this exercise has been scheduled during the run of this scheduler.
     frequency: usize,
 
@@ -151,9 +148,6 @@ struct Candidate {
     /// Whether this candidate comes from a lesson where the search stopped because the lesson's
     /// average score is still below the passing score.
     dead_end: bool,
-
-    /// The sum of the number of dependents of the lesson and course of this exercise.
-    num_dependents: usize,
 
     /// The weight of the units that the lesson and course of this exercise encompass. Higher values
     /// mean that practicing this exercise provides more coverage of the graph.
@@ -375,15 +369,10 @@ impl DepthFirstScheduler {
                         .unit_scorer
                         .get_unit_score(exercise_id)?
                         .unwrap_or_default(),
-                    num_trials: self
-                        .unit_scorer
-                        .get_exercise_num_trials(exercise_id)?
-                        .unwrap_or_default(),
                     urgency: self.unit_scorer.get_exercise_urgency(exercise_id)?,
                     velocity: self.unit_scorer.get_exercise_velocity(exercise_id)?,
                     frequency: frequency_map.get(&exercise_id).copied().unwrap_or(0),
                     dead_end: false,
-                    num_dependents: self.data.get_num_dependents(item.unit_id, course_id),
                     encompasses_weight: 0.0,
                     encompassed_weight: 0.0,
                 })
@@ -955,15 +944,10 @@ impl DepthFirstScheduler {
                             .unit_scorer
                             .get_unit_score(unit_id)?
                             .unwrap_or_default(),
-                        num_trials: self
-                            .unit_scorer
-                            .get_exercise_num_trials(unit_id)?
-                            .unwrap_or_default(),
                         urgency: self.unit_scorer.get_exercise_urgency(unit_id)?,
                         velocity: self.unit_scorer.get_exercise_velocity(unit_id)?,
                         frequency: *frequency_map.get(&unit_id).unwrap_or(&0),
                         dead_end: false,
-                        num_dependents: self.data.get_num_dependents(lesson_id, course_id),
                         encompasses_weight: 0.0,
                         encompassed_weight: 0.0,
                     });

--- a/src/scheduler/data.rs
+++ b/src/scheduler/data.rs
@@ -164,16 +164,6 @@ impl SchedulerData {
             .collect();
     }
 
-    /// Returns the number of units that are dependents of an exercise in the given lesson and
-    /// course.
-    #[inline]
-    #[must_use]
-    pub fn get_num_dependents(&self, lesson_id: Ustr, course_id: Ustr) -> usize {
-        let graph = self.unit_graph.read();
-        graph.get_dependents(lesson_id).unwrap_or_default().len()
-            + graph.get_dependents(course_id).unwrap_or_default().len()
-    }
-
     /// Returns all the units that supersede the unit with the given ID.
     #[inline]
     #[must_use]

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -26,14 +26,6 @@ const MIN_WEIGHT: f32 = 100.0;
 /// factor.
 const EXERCISE_SCORE_WEIGHT_FACTOR: f32 = 200.0;
 
-/// The part of the weight that depends on the lesson's score will be (5.0 - score) times this
-/// factor.
-const LESSON_SCORE_WEIGHT_FACTOR: f32 = 100.0;
-
-/// The part of the weight that depends on the course's score will be (5.0 - score) times this
-/// factor.
-const COURSE_SCORE_WEIGHT_FACTOR: f32 = 50.0;
-
 /// The factor used to compute the part of the weight that depends on how many other units the
 /// exercise is encompassed by in the initial batch.
 const ENCOMPASSED_FACTOR: f32 = -250.0;
@@ -70,13 +62,6 @@ const MAX_NUM_TRIALS_WEIGHT: f32 = 1000.0;
 
 /// The factor by which the weight is mulitiplied when the number of trials is increased.
 const NUM_TRIALS_FACTOR: f32 = 0.75;
-
-/// The factor used to compute the part of the weight that depends on the number of days since this
-/// exercise was last seen.
-const LAST_SEEN_WEIGHT_PER_DAY: f32 = 5.0;
-
-/// The maximum amount of weight this component can add.
-const MAX_LAST_SEEN_WEIGHT: f32 = 1000.0;
 
 /// The maximum weight that depends on the frequency of exercises from the same lesson. The weight
 /// will be divided equally among all the exercises from the same lesson.
@@ -152,53 +137,41 @@ impl CandidateFilter {
         course_frequency
     }
 
-    /// Computes the weight assigned to a candidate that will be used to select it during the
+    /// Computes the cost assigned to a candidate that will be used to select it during the
     /// filtering phase. The weight is based on the following factors:
     ///
     /// 1. The candidate's exercise score. A higher score is assigned less weight to give them
     ///    precedence over candidates with lower scores.
-    /// 2. The candidate's lesson score. Exercises from lessons with a higher score will be shown
-    ///    less often.
-    /// 3. The candidate's course score. Exercises from courses with a higher score will be shown
-    ///    less often.
-    /// 4. The number of units the exercise is encompassed by in the initial batch. A higher
+    /// 2. The number of units the exercise is encompassed by in the initial batch. A higher
     ///    negative weight is assigned to exercises with a higher value to avoid selecting these
     ///    exercises.
-    /// 5. The number of units the exercise encompasses. Exercises that encompass more units are
+    /// 3. The number of units the exercise encompasses. Exercises that encompass more units are
     ///    given more weight since they implicitly review more material.
-    /// 6. The number of hops taken by the graph search to find the candidate. A higher number of
+    /// 4. The number of hops taken by the graph search to find the candidate. A higher number of
     ///    hops is assigned more weight to give precedence to candidates from more advanced
     ///    material.
-    /// 7. The number of dependents of the lesson and course of the candidate. Exercises from
+    /// 5. The number of dependents of the lesson and course of the candidate. Exercises from
     ///    lessons and courses that unlock more units are given higher weight.
-    /// 8. The frequency with which the candidate has been scheduled during the run of the
+    /// 6. The frequency with which the candidate has been scheduled during the run of the
     ///    scheduler. A higher frequency is assigned less weight to avoid selecting the same
     ///    exercises too often during the same session.
-    /// 9. The number of trials for that candidate. A higher number of trials is assigned less
+    /// 7. The number of trials for that candidate. A higher number of trials is assigned less
     ///    weight to favor exercises that have been practiced fewer times.
-    /// 10. The number of days since this candidate was last seen. More days since last seen gets
-    ///     more weight.
-    /// 11. The number of candidates in the same lesson. The more candidates there are in the same
+    /// 8. The number of candidates in the same lesson. The more candidates there are in the same
     ///     lesson, the less weight each candidate is assigned to avoid selecting too many exercises
     ///     from the same lesson.
-    /// 12. The number of candidates in the same course. The same logic applies as for the lesson
+    /// 9. The number of candidates in the same course. The same logic applies as for the lesson
     ///     frequency.
-    /// 13. Whether the candidate comes from a dead-end in the traversal. Dead-end candidates get a
+    /// 10. Whether the candidate comes from a dead-end in the traversal. Dead-end candidates get a
     ///     fixed bonus to prioritize the learner's frontier.
-    /// 14. The candidate's score velocity. The absolute value of the velocity is multiplied by a
+    /// 11. The candidate's score velocity. The absolute value of the velocity is multiplied by a
     ///     factor.
-    /// 15. Whether the candidate has a stagnant velocity. Non-mastered candidates with a stagnant
+    /// 12. Whether the candidate has a stagnant velocity. Non-mastered candidates with a stagnant
     ///     velocity get a weight bonus, while mastered candidates with a stagnant velocity get a
     ///     penalty.
-    fn candidate_weight(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
+    fn candidate_cost(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
         // A part of the score will depend on the score of the exercise.
         let mut weight = EXERCISE_SCORE_WEIGHT_FACTOR * (5.0 - c.exercise_score).max(0.0);
-
-        // A part of the score will depend on the score of the lesson.
-        weight += LESSON_SCORE_WEIGHT_FACTOR * (5.0 - c.lesson_score).max(0.0);
-
-        // A part of the score will depend on the score of the course.
-        weight += COURSE_SCORE_WEIGHT_FACTOR * (5.0 - c.course_score).max(0.0);
 
         // A part of the score will depend on the weight with which the exercise is encompassed
         // by other exercises in the initial batch.
@@ -224,12 +197,6 @@ impl CandidateFilter {
         // A part of the weight is based on the number of trials for that exercise.
         weight += MAX_NUM_TRIALS_WEIGHT * NUM_TRIALS_FACTOR.powf(c.num_trials as f32);
 
-        // A part of the weight is based on the number of days since this exercise was last seen.
-        // The computation includes a factor based on the score so that exercises with lower score
-        // are given higher weight.
-        weight += (LAST_SEEN_WEIGHT_PER_DAY * c.last_seen * (5.0 - c.exercise_score))
-            .clamp(0.0, MAX_LAST_SEEN_WEIGHT);
-
         // A part of the weight is based on the number of candidates in the same lesson.
         weight += MAX_LESSON_FREQUENCY_WEIGHT / lesson_freq.max(1) as f32;
 
@@ -244,7 +211,7 @@ impl CandidateFilter {
         // A part of the weight is based on the candidate's score velocity. All exercises get a
         // boost based on the absolute value of the velocity. Stagnant exercises get a boost or a
         // penalty depending on whether they are mastered.
-        if let Some(velocity) = c.score_velocity {
+        if let Some(velocity) = c.velocity {
             weight += VELOCITY_WEIGHT_FACTOR * velocity.abs();
             if velocity.abs() < STAGNANT_VELOCITY_THRESHOLD {
                 if c.exercise_score >= MASTERED_SCORE_THRESHOLD {
@@ -257,6 +224,15 @@ impl CandidateFilter {
 
         // Give each candidates a minimum weight.
         weight.max(MIN_WEIGHT)
+    }
+
+    /// Computes the weight assigned to a candidate that will be used to select it during the
+    /// filtering phase. The weight is derived from the formula `urgency / sqrt(cost)`, where the
+    /// urgency represents how important it is to schedule the exercise, and the cost represents how
+    /// "expensive" it is to schedule the exercise.
+    fn candidate_weight(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
+        let cost = Self::candidate_cost(c, lesson_freq, course_freq);
+        c.urgency / cost.sqrt()
     }
 
     /// Takes a list of candidates and randomly selects `num_to_select` candidates among them. Each
@@ -673,48 +649,10 @@ mod test {
     fn higher_exercise_score_less_weight() {
         let c1 = Candidate {
             exercise_score: 5.0,
-            lesson_score: 5.0,
-            course_score: 5.0,
             ..Default::default()
         };
         let c2 = Candidate {
             exercise_score: 1.0,
-            lesson_score: 1.0,
-            course_score: 1.0,
-            ..Default::default()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates with a higher lesson score are given less weight.
-    #[test]
-    fn higher_lesson_score_less_weight() {
-        let c1 = Candidate {
-            lesson_score: 5.0,
-            ..Default::default()
-        };
-        let c2 = Candidate {
-            lesson_score: 1.0,
-            ..Default::default()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates with a higher course score are given less weight.
-    #[test]
-    fn higher_course_score_less_weight() {
-        let c1 = Candidate {
-            course_score: 5.0,
-            ..Default::default()
-        };
-        let c2 = Candidate {
-            course_score: 1.0,
             ..Default::default()
         };
         assert!(
@@ -754,42 +692,6 @@ mod test {
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
                 < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates seen less recently are given more weight.
-    #[test]
-    fn more_days_since_last_seen_more_weight() {
-        // Candidates with the same exercise score but different last seen values.
-        let c1 = Candidate {
-            last_seen: 1.0,
-            exercise_score: 4.0,
-            ..Default::default()
-        };
-        let c2 = Candidate {
-            last_seen: 20.0,
-            exercise_score: 2.0,
-            ..Default::default()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-
-        // Candidates with different exercise scores but the same last seen values.
-        let c3 = Candidate {
-            last_seen: 10.0,
-            exercise_score: 4.0,
-            ..Default::default()
-        };
-        let c4 = Candidate {
-            last_seen: 10.0,
-            exercise_score: 2.0,
-            ..Default::default()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c3, 1, 1)
-                < CandidateFilter::candidate_weight(&c4, 1, 1)
         );
     }
 
@@ -953,8 +855,6 @@ mod test {
         // Create a candidate that should have a very low weight.
         let c = Candidate {
             exercise_score: 5.0,
-            lesson_score: 5.0,
-            course_score: 5.0,
             num_trials: 1000,
             frequency: 1000,
             ..Default::default()
@@ -977,11 +877,11 @@ mod test {
     fn higher_velocity_more_weight() {
         let base = Candidate {
             exercise_score: 2.0,
-            score_velocity: Some(1.0),
+            velocity: Some(1.0),
             ..Default::default()
         };
         let low_velocity = Candidate {
-            score_velocity: Some(0.5),
+            velocity: Some(0.5),
             ..base.clone()
         };
         assert!(
@@ -998,7 +898,7 @@ mod test {
             ..Default::default()
         };
         let negative = Candidate {
-            score_velocity: Some(-1.0),
+            velocity: Some(-1.0),
             ..base.clone()
         };
         assert!(
@@ -1015,7 +915,7 @@ mod test {
             ..Default::default()
         };
         let stagnant = Candidate {
-            score_velocity: Some(0.05),
+            velocity: Some(0.05),
             ..base.clone()
         };
         let base_weight = CandidateFilter::candidate_weight(&base, 1, 1);
@@ -1031,7 +931,7 @@ mod test {
             ..Default::default()
         };
         let stagnant = Candidate {
-            score_velocity: Some(0.05),
+            velocity: Some(0.05),
             ..base.clone()
         };
         assert!(
@@ -1049,7 +949,7 @@ mod test {
             ..Default::default()
         };
         let active = Candidate {
-            score_velocity: Some(0.5),
+            velocity: Some(0.5),
             ..base.clone()
         };
         let base_weight = CandidateFilter::candidate_weight(&base, 1, 1);

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// The minimum candidate cost.
-const MIN_CANDIDATE_COST: f32 = 1.0;
+const MIN_CANDIDATE_COST: f32 = 0.25;
 
 /// The maximum candidate cost.
 const MAX_CANDIDATE_COST: f32 = 1000.0;

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// The minimum candidate cost.
-const MIN_CANDIDATE_COST: f32 = 0.25;
+const MIN_CANDIDATE_COST: f32 = 1.0;
 
 /// The maximum candidate cost.
 const MAX_CANDIDATE_COST: f32 = 1000.0;
@@ -51,11 +51,6 @@ const COURSE_FREQUENCY_COST_COEFFICIENT: f32 = 0.35;
 /// Reduction applied to the log-cost of dead-end candidates.
 const DEAD_END_COST_BONUS: f32 = 0.8;
 
-/// The batch size will be adjusted if there are not enough candidates (at least three times the
-/// batch size) to create a batch of the size specified in the scheduler options. This value is the
-/// minimum value for such an adjustment.
-const MIN_DYNAMIC_BATCH_SIZE: usize = 10;
-
 /// Coefficient applied to the absolute value of the velocity in the candidate cost.
 const VELOCITY_COST_COEFFICIENT: f32 = 0.2;
 
@@ -71,6 +66,11 @@ const STAGNANT_VELOCITY_THRESHOLD: f32 = 0.2;
 /// The exercise score threshold above which a candidate is considered mastered for the purpose of
 /// applying the stagnant velocity bonus or penalty.
 const MASTERED_SCORE_THRESHOLD: f32 = 4.0;
+
+/// The batch size will be adjusted if there are not enough candidates (at least three times the
+/// batch size) to create a batch of the size specified in the scheduler options. This value is the
+/// minimum value for such an adjustment.
+const MIN_DYNAMIC_BATCH_SIZE: usize = 10;
 
 /// The filter used to reduce the candidates found during the search to a final batch of exercises.
 pub(super) struct CandidateFilter {

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// The minimum candidate weight.
-const MIN_CANDIDATE_WEIGHT: f32 = 0.01;
+const MIN_CANDIDATE_WEIGHT: f32 = 0.05;
 
 /// The minimum candidate cost.
 const MIN_CANDIDATE_COST: f32 = 0.25;

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -745,6 +745,24 @@ mod test {
         );
     }
 
+    /// Verifies that the weight of very good candidates is clamped to the minimum weight to ensure
+    /// they are still considered.
+    #[test]
+    fn candidate_weight_clamped() {
+        let c = Candidate {
+            depth: 500.0,
+            num_dependents: 500,
+            encompasses_weight: 500.0,
+            dead_end: true,
+            urgency: 0.0001,
+            ..weighted_candidate()
+        };
+        assert_eq!(
+            CandidateFilter::candidate_weight(&c, 1, 1),
+            MIN_CANDIDATE_WEIGHT
+        );
+    }
+
     /// Verifies that candidates with higher absolute velocity get slightly less weight.
     #[test]
     fn higher_velocity_less_weight() {

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -651,91 +651,6 @@ mod test {
         );
     }
 
-    /// Verifies that the mastery windows are adjusted based on the success rate.
-    #[test]
-    fn adjusted_mastery_windows() {
-        // In the optimal zone (75%-90%), windows are unchanged.
-        let options = SchedulerOptions::default();
-        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.85);
-        assert_eq!(
-            adjusted.new_window_opts.percentage,
-            options.new_window_opts.percentage
-        );
-        assert_eq!(
-            adjusted.target_window_opts.percentage,
-            options.target_window_opts.percentage
-        );
-        assert_eq!(
-            adjusted.current_window_opts.percentage,
-            options.current_window_opts.percentage
-        );
-        assert_eq!(
-            adjusted.easy_window_opts.percentage,
-            options.easy_window_opts.percentage
-        );
-        assert_eq!(
-            adjusted.mastered_window_opts.percentage,
-            options.mastered_window_opts.percentage
-        );
-
-        // At the boundaries of the optimal zone, windows are also unchanged.
-        let adjusted_low = CandidateFilter::adjusted_mastery_windows(&options, 0.75);
-        assert_eq!(
-            adjusted_low.new_window_opts.percentage,
-            options.new_window_opts.percentage
-        );
-        let adjusted_high = CandidateFilter::adjusted_mastery_windows(&options, 0.90);
-        assert_eq!(
-            adjusted_high.new_window_opts.percentage,
-            options.new_window_opts.percentage
-        );
-
-        // Success rate > 90%: too easy, shift toward harder windows.
-        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.95);
-        assert!(adjusted.new_window_opts.percentage > options.new_window_opts.percentage);
-        assert!(adjusted.target_window_opts.percentage > options.target_window_opts.percentage);
-        assert!(adjusted.easy_window_opts.percentage < options.easy_window_opts.percentage);
-        assert!(adjusted.mastered_window_opts.percentage < options.mastered_window_opts.percentage);
-
-        // Success rate 50%-75%: too hard, shift toward easier windows.
-        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.60);
-        assert!(adjusted.new_window_opts.percentage < options.new_window_opts.percentage);
-        assert!(adjusted.target_window_opts.percentage < options.target_window_opts.percentage);
-        assert!(adjusted.easy_window_opts.percentage > options.easy_window_opts.percentage);
-        assert!(adjusted.mastered_window_opts.percentage > options.mastered_window_opts.percentage);
-
-        // Success rate < 50%: very hard, shift even more toward easier windows.
-        let adjusted_very_hard = CandidateFilter::adjusted_mastery_windows(&options, 0.30);
-        let adjusted_hard = CandidateFilter::adjusted_mastery_windows(&options, 0.60);
-        assert!(
-            adjusted_very_hard.easy_window_opts.percentage
-                > adjusted_hard.easy_window_opts.percentage
-        );
-        assert!(
-            adjusted_very_hard.mastered_window_opts.percentage
-                > adjusted_hard.mastered_window_opts.percentage
-        );
-        assert!(
-            adjusted_very_hard.new_window_opts.percentage
-                < adjusted_hard.new_window_opts.percentage
-        );
-        assert!(
-            adjusted_very_hard.target_window_opts.percentage
-                < adjusted_hard.target_window_opts.percentage
-        );
-
-        // All five windows always sum to 1.0.
-        for rate in [0.0, 0.30, 0.60, 0.80, 0.95, 1.0] {
-            let adj = CandidateFilter::adjusted_mastery_windows(&options, rate);
-            let sum = adj.new_window_opts.percentage
-                + adj.target_window_opts.percentage
-                + adj.current_window_opts.percentage
-                + adj.easy_window_opts.percentage
-                + adj.mastered_window_opts.percentage;
-            assert!((sum - 1.0).abs() < 1e-6);
-        }
-    }
-
     /// Verifies that candidates from courses with more candidates are given less weight.
     #[test]
     fn higher_course_frequency_less_weight() {
@@ -924,5 +839,90 @@ mod test {
             CandidateFilter::candidate_weight(&active, 1, 1)
                 < CandidateFilter::candidate_weight(&base, 1, 1)
         );
+    }
+
+    /// Verifies that the mastery windows are adjusted based on the success rate.
+    #[test]
+    fn adjusted_mastery_windows() {
+        // In the optimal zone (75%-90%), windows are unchanged.
+        let options = SchedulerOptions::default();
+        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.85);
+        assert_eq!(
+            adjusted.new_window_opts.percentage,
+            options.new_window_opts.percentage
+        );
+        assert_eq!(
+            adjusted.target_window_opts.percentage,
+            options.target_window_opts.percentage
+        );
+        assert_eq!(
+            adjusted.current_window_opts.percentage,
+            options.current_window_opts.percentage
+        );
+        assert_eq!(
+            adjusted.easy_window_opts.percentage,
+            options.easy_window_opts.percentage
+        );
+        assert_eq!(
+            adjusted.mastered_window_opts.percentage,
+            options.mastered_window_opts.percentage
+        );
+
+        // At the boundaries of the optimal zone, windows are also unchanged.
+        let adjusted_low = CandidateFilter::adjusted_mastery_windows(&options, 0.75);
+        assert_eq!(
+            adjusted_low.new_window_opts.percentage,
+            options.new_window_opts.percentage
+        );
+        let adjusted_high = CandidateFilter::adjusted_mastery_windows(&options, 0.90);
+        assert_eq!(
+            adjusted_high.new_window_opts.percentage,
+            options.new_window_opts.percentage
+        );
+
+        // Success rate > 90%: too easy, shift toward harder windows.
+        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.95);
+        assert!(adjusted.new_window_opts.percentage > options.new_window_opts.percentage);
+        assert!(adjusted.target_window_opts.percentage > options.target_window_opts.percentage);
+        assert!(adjusted.easy_window_opts.percentage < options.easy_window_opts.percentage);
+        assert!(adjusted.mastered_window_opts.percentage < options.mastered_window_opts.percentage);
+
+        // Success rate 50%-75%: too hard, shift toward easier windows.
+        let adjusted = CandidateFilter::adjusted_mastery_windows(&options, 0.60);
+        assert!(adjusted.new_window_opts.percentage < options.new_window_opts.percentage);
+        assert!(adjusted.target_window_opts.percentage < options.target_window_opts.percentage);
+        assert!(adjusted.easy_window_opts.percentage > options.easy_window_opts.percentage);
+        assert!(adjusted.mastered_window_opts.percentage > options.mastered_window_opts.percentage);
+
+        // Success rate < 50%: very hard, shift even more toward easier windows.
+        let adjusted_very_hard = CandidateFilter::adjusted_mastery_windows(&options, 0.30);
+        let adjusted_hard = CandidateFilter::adjusted_mastery_windows(&options, 0.60);
+        assert!(
+            adjusted_very_hard.easy_window_opts.percentage
+                > adjusted_hard.easy_window_opts.percentage
+        );
+        assert!(
+            adjusted_very_hard.mastered_window_opts.percentage
+                > adjusted_hard.mastered_window_opts.percentage
+        );
+        assert!(
+            adjusted_very_hard.new_window_opts.percentage
+                < adjusted_hard.new_window_opts.percentage
+        );
+        assert!(
+            adjusted_very_hard.target_window_opts.percentage
+                < adjusted_hard.target_window_opts.percentage
+        );
+
+        // All five windows always sum to 1.0.
+        for rate in [0.0, 0.30, 0.60, 0.80, 0.95, 1.0] {
+            let adj = CandidateFilter::adjusted_mastery_windows(&options, rate);
+            let sum = adj.new_window_opts.percentage
+                + adj.target_window_opts.percentage
+                + adj.current_window_opts.percentage
+                + adj.easy_window_opts.percentage
+                + adj.mastered_window_opts.percentage;
+            assert!((sum - 1.0).abs() < 1e-6);
+        }
     }
 }

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -11,7 +11,7 @@
 //!    score, and the frequency with which the exercise has been scheduled in the past.
 
 use rand::{rng, seq::IndexedRandom};
-use ustr::{UstrMap, UstrSet};
+use ustr::UstrSet;
 
 use crate::{
     data::{MasteryWindow, SchedulerOptions},
@@ -22,46 +22,28 @@ use crate::{
 const MIN_CANDIDATE_WEIGHT: f32 = 0.05;
 
 /// The minimum candidate cost.
-const MIN_CANDIDATE_COST: f32 = 0.25;
+const MIN_CANDIDATE_COST: f32 = 0.05;
 
 /// The maximum candidate cost.
 const MAX_CANDIDATE_COST: f32 = 100.0;
 
 /// Coefficient applied to the depth term in the candidate cost.
-const DEPTH_COST_COEFFICIENT: f32 = 0.6;
-
-/// Coefficient applied to the number of dependents term in the candidate cost.
-const NUM_DEPENDENTS_COST_COEFFICIENT: f32 = 0.45;
+const DEPTH_COST_COEFFICIENT: f32 = 0.7;
 
 /// Coefficient applied to the coverage term in the candidate cost.
-const ENCOMPASSES_COST_COEFFICIENT: f32 = 0.45;
+const ENCOMPASSES_COST_COEFFICIENT: f32 = 0.9;
 
 /// Coefficient applied to the redundancy term in the candidate cost.
-const ENCOMPASSED_COST_COEFFICIENT: f32 = 0.8;
+const ENCOMPASSED_COST_COEFFICIENT: f32 = 0.6;
 
 /// Coefficient applied to the scheduled frequency term in the candidate cost.
-const SCHEDULED_FREQUENCY_COST_COEFFICIENT: f32 = 0.7;
-
-/// Coefficient applied to the number of trials term in the candidate cost.
-const NUM_TRIALS_COST_COEFFICIENT: f32 = 0.45;
-
-/// Coefficient applied to the lesson candidate frequency term in the candidate cost.
-const LESSON_FREQUENCY_COST_COEFFICIENT: f32 = 0.35;
-
-/// Coefficient applied to the course candidate frequency term in the candidate cost.
-const COURSE_FREQUENCY_COST_COEFFICIENT: f32 = 0.25;
+const SCHEDULED_FREQUENCY_COST_COEFFICIENT: f32 = 2.0;
 
 /// Reduction applied to the log-cost of dead-end candidates.
-const DEAD_END_COST_BONUS: f32 = 0.6;
+const DEAD_END_COST_BONUS: f32 = 1.0;
 
-/// Coefficient applied to the absolute value of the velocity in the candidate cost.
-const VELOCITY_COST_COEFFICIENT: f32 = 0.15;
-
-/// Reduction applied to the log-cost of non-mastered candidates with stagnant velocity.
-const STAGNANT_UNMASTERED_COST_BONUS: f32 = 0.7;
-
-/// Penalty applied to the log-cost of mastered candidates with stagnant velocity.
-const STAGNANT_MASTERED_COST_PENALTY: f32 = 0.7;
+/// Coefficient applied to the signed velocity term in the candidate cost.
+const VELOCITY_COST_COEFFICIENT: f32 = 0.5;
 
 /// The velocity threshold under which a candidate is considered to be stagnant.
 const STAGNANT_VELOCITY_THRESHOLD: f32 = 0.2;
@@ -69,6 +51,12 @@ const STAGNANT_VELOCITY_THRESHOLD: f32 = 0.2;
 /// The exercise score threshold above which a candidate is considered mastered for the purpose of
 /// applying the stagnant velocity bonus or penalty.
 const MASTERED_SCORE_THRESHOLD: f32 = 4.0;
+
+/// Reduction applied to the log-cost of non-mastered candidates with stagnant velocity.
+const STAGNANT_UNMASTERED_COST_BONUS: f32 = 0.7;
+
+/// Penalty applied to the log-cost of mastered candidates with stagnant velocity.
+const STAGNANT_MASTERED_COST_PENALTY: f32 = 1.0;
 
 /// The batch size will be adjusted if there are not enough candidates (at least three times the
 /// batch size) to create a batch of the size specified in the scheduler options. This value is the
@@ -101,57 +89,32 @@ impl CandidateFilter {
             .collect()
     }
 
-    /// Counts the number of candidates from each lesson.
-    fn count_lesson_frequency(candidates: &[Candidate]) -> UstrMap<u32> {
-        let mut lesson_frequency = UstrMap::default();
-        for candidate in candidates {
-            *lesson_frequency.entry(candidate.lesson_id).or_default() += 1;
-        }
-        lesson_frequency
-    }
-
-    /// Counts the number of candidates from each course.
-    fn count_course_frequency(candidates: &[Candidate]) -> UstrMap<u32> {
-        let mut course_frequency = UstrMap::default();
-        for candidate in candidates {
-            *course_frequency.entry(candidate.course_id).or_default() += 1;
-        }
-        course_frequency
-    }
-
     /// Computes the cost assigned to a candidate that will be used to select it during the
     /// filtering phase. The cost is built in log-space so that individual factors can be summed,
     /// then converted back to linear space by exponentiation. Lower cost means a candidate should
     /// be selected more often.
     ///
     /// 1. Greater depth lowers the cost.
-    /// 2. More dependents lower the cost.
-    /// 3. Higher coverage lowers the cost.
-    /// 4. Being encompassed by other candidates raises the cost.
-    /// 5. More repeated scheduling raises the cost.
-    /// 6. More trials raise the cost.
-    /// 7. Higher lesson and course candidate frequency raise the cost.
-    /// 8. Dead-end candidates get a cost reduction.
-    /// 9. Higher absolute velocity raises the cost slightly.
-    /// 10. Stagnant non-mastered candidates get a cost reduction.
-    /// 11. Stagnant mastered candidates get a cost penalty.
-    fn candidate_cost(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
+    /// 2. Higher coverage lowers the cost.
+    /// 3. Being encompassed by other candidates raises the cost.
+    /// 4. More repeated scheduling raises the cost.
+    /// 5. Dead-end candidates get a cost reduction.
+    /// 6. Higher positive velocity lowers the cost slightly, while negative velocity raises it.
+    /// 7. Stagnant non-mastered candidates get a cost reduction.
+    /// 8. Stagnant mastered candidates get a cost penalty.
+    fn candidate_cost(c: &Candidate) -> f32 {
         let mut log_cost = 0.0;
         log_cost -= DEPTH_COST_COEFFICIENT * c.depth.ln_1p();
-        log_cost -= NUM_DEPENDENTS_COST_COEFFICIENT * (c.num_dependents as f32).ln_1p();
         log_cost -= ENCOMPASSES_COST_COEFFICIENT * c.encompasses_weight.ln_1p();
         log_cost += ENCOMPASSED_COST_COEFFICIENT * c.encompassed_weight.ln_1p();
-        log_cost += SCHEDULED_FREQUENCY_COST_COEFFICIENT * c.frequency as f32;
-        log_cost += NUM_TRIALS_COST_COEFFICIENT * (c.num_trials as f32).ln_1p();
-        log_cost += LESSON_FREQUENCY_COST_COEFFICIENT * (lesson_freq.max(1) as f32).ln();
-        log_cost += COURSE_FREQUENCY_COST_COEFFICIENT * (course_freq.max(1) as f32).ln();
+        log_cost += SCHEDULED_FREQUENCY_COST_COEFFICIENT * (c.frequency as f32).ln_1p();
 
         if c.dead_end {
             log_cost -= DEAD_END_COST_BONUS;
         }
 
         if let Some(velocity) = c.velocity {
-            log_cost += VELOCITY_COST_COEFFICIENT * velocity.abs();
+            log_cost += VELOCITY_COST_COEFFICIENT * -velocity.ln_1p();
             if velocity.abs() < STAGNANT_VELOCITY_THRESHOLD {
                 if c.exercise_score >= MASTERED_SCORE_THRESHOLD {
                     log_cost += STAGNANT_MASTERED_COST_PENALTY;
@@ -168,8 +131,8 @@ impl CandidateFilter {
     /// filtering phase. The weight is derived from the formula `urgency / sqrt(cost)`, where the
     /// urgency represents how important it is to schedule the exercise, and the cost represents how
     /// "expensive" it is to schedule the exercise.
-    fn candidate_weight(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
-        let cost = Self::candidate_cost(c, lesson_freq, course_freq);
+    fn candidate_weight(c: &Candidate) -> f32 {
+        let cost = Self::candidate_cost(c);
         (c.urgency / cost.sqrt()).max(MIN_CANDIDATE_WEIGHT)
     }
 
@@ -187,22 +150,12 @@ impl CandidateFilter {
             return (candidates.to_vec(), vec![]);
         }
 
-        // Count the number of candidates in each lesson and course.
-        let lesson_freq = Self::count_lesson_frequency(candidates);
-        let course_freq = Self::count_course_frequency(candidates);
-
         // Otherwise, assign a weight to each candidate and perform a weighted random selection.
         // Safe to unwrap the result, as this function panics if `num_to_select` is greater than the
         // size of `candidates`, but that is checked above.
         let mut rng = rng();
         let selected: Vec<Candidate> = candidates
-            .sample_weighted(&mut rng, num_to_select, |c| {
-                Self::candidate_weight(
-                    c,
-                    lesson_freq.get(&c.lesson_id).copied().unwrap_or(0),
-                    course_freq.get(&c.course_id).copied().unwrap_or(0),
-                )
-            })
+            .sample_weighted(&mut rng, num_to_select, Self::candidate_weight)
             .unwrap()
             .cloned()
             .collect();
@@ -421,34 +374,6 @@ mod test {
         assert_eq!(CandidateFilter::dynamic_batch_size(50, 200), 50);
     }
 
-    /// Verifies that the candidates per lesson are counted correctly.
-    #[test]
-    fn count_lesson_frequency() {
-        // Create a list of candidates with different lessons.
-        let candidates = vec![
-            Candidate {
-                lesson_id: Ustr::from("lesson1"),
-                ..Default::default()
-            },
-            Candidate {
-                lesson_id: Ustr::from("lesson1"),
-                ..Default::default()
-            },
-            Candidate {
-                lesson_id: Ustr::from("lesson2"),
-                ..Default::default()
-            },
-            Candidate::default(),
-        ];
-
-        // Count the number of candidates per lesson.
-        let lesson_frequency = CandidateFilter::count_lesson_frequency(&candidates);
-        assert_eq!(lesson_frequency.len(), 3);
-        assert_eq!(lesson_frequency.get(&Ustr::from("lesson1")), Some(&2));
-        assert_eq!(lesson_frequency.get(&Ustr::from("lesson2")), Some(&1));
-        assert_eq!(lesson_frequency.get(&Ustr::from("")), Some(&1));
-    }
-
     /// Verifies the logic to select candidates in the right candidate window.
     #[test]
     fn candidates_in_window() {
@@ -535,7 +460,7 @@ mod test {
         assert!(final_candidates.len() < batch_size);
 
         // Verify that remainders are not added when the batch is already full enough.
-        let mut final_candidates_full = (0..batch_size * 2 / 3 + 1)
+        let mut final_candidates_full = (0..batch_size * 3 / 4 + 1)
             .map(|i| Candidate {
                 exercise_id: Ustr::from(&format!("exercise{}", i)),
                 ..Default::default()
@@ -573,24 +498,7 @@ mod test {
             depth: 10.0,
             ..weighted_candidate()
         };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates with more dependents are given more weight.
-    #[test]
-    fn more_dependents_more_weight() {
-        let c1 = weighted_candidate();
-        let c2 = Candidate {
-            num_dependents: 50,
-            ..weighted_candidate()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
+        assert!(CandidateFilter::candidate_weight(&c1) < CandidateFilter::candidate_weight(&c2));
     }
 
     /// Verifies that candidates with higher urgency are given more weight.
@@ -604,10 +512,7 @@ mod test {
             urgency: 0.25,
             ..Default::default()
         };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                > CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
+        assert!(CandidateFilter::candidate_weight(&c1) > CandidateFilter::candidate_weight(&c2));
     }
 
     /// Verifies that candidates that have been scheduled more often are given less weight.
@@ -621,47 +526,7 @@ mod test {
             frequency: 1,
             ..weighted_candidate()
         };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates with fewer trials are given more weight.
-    #[test]
-    fn fewer_trials_more_weight() {
-        let c1 = Candidate {
-            num_trials: 5,
-            ..weighted_candidate()
-        };
-        let c2 = Candidate {
-            num_trials: 1,
-            ..weighted_candidate()
-        };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
-    }
-
-    /// Verifies that candidates from lessons with more candidates are given less weight.
-    #[test]
-    fn higher_lesson_frequency_less_weight() {
-        let c = weighted_candidate();
-        assert!(
-            CandidateFilter::candidate_weight(&c, 10, 1)
-                < CandidateFilter::candidate_weight(&c, 3, 1)
-        );
-    }
-
-    /// Verifies that candidates from courses with more candidates are given less weight.
-    #[test]
-    fn higher_course_frequency_less_weight() {
-        let c = weighted_candidate();
-        assert!(
-            CandidateFilter::candidate_weight(&c, 1, 10)
-                < CandidateFilter::candidate_weight(&c, 1, 3)
-        );
+        assert!(CandidateFilter::candidate_weight(&c1) < CandidateFilter::candidate_weight(&c2));
     }
 
     /// Verifies that candidates that are encompassed by more exercises in the initial batch are
@@ -676,10 +541,7 @@ mod test {
             encompassed_weight: 3.0,
             ..weighted_candidate()
         };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
+        assert!(CandidateFilter::candidate_weight(&c1) < CandidateFilter::candidate_weight(&c2));
     }
 
     /// Verifies that candidates that encompass more units are given more weight.
@@ -693,10 +555,7 @@ mod test {
             encompasses_weight: 3.0,
             ..weighted_candidate()
         };
-        assert!(
-            CandidateFilter::candidate_weight(&c1, 1, 1)
-                > CandidateFilter::candidate_weight(&c2, 1, 1)
-        );
+        assert!(CandidateFilter::candidate_weight(&c1) > CandidateFilter::candidate_weight(&c2));
     }
 
     /// Verifies that dead-end candidates have lower cost and therefore more weight.
@@ -709,12 +568,10 @@ mod test {
         };
 
         assert!(
-            CandidateFilter::candidate_cost(&dead_end, 1, 1)
-                < CandidateFilter::candidate_cost(&base, 1, 1)
+            CandidateFilter::candidate_cost(&dead_end) < CandidateFilter::candidate_cost(&base)
         );
         assert!(
-            CandidateFilter::candidate_weight(&dead_end, 1, 1)
-                > CandidateFilter::candidate_weight(&base, 1, 1)
+            CandidateFilter::candidate_weight(&dead_end) > CandidateFilter::candidate_weight(&base)
         );
     }
 
@@ -723,24 +580,22 @@ mod test {
     fn candidate_cost_clamped() {
         let favorable = Candidate {
             depth: 500.0,
-            num_dependents: 500,
             encompasses_weight: 500.0,
             dead_end: true,
             ..weighted_candidate()
         };
         let unfavorable = Candidate {
-            num_trials: 1000,
             frequency: 1000,
             encompassed_weight: 1000.0,
             velocity: Some(10.0),
             ..weighted_candidate()
         };
         assert_eq!(
-            CandidateFilter::candidate_cost(&favorable, 1, 1),
+            CandidateFilter::candidate_cost(&favorable),
             MIN_CANDIDATE_COST
         );
         assert_eq!(
-            CandidateFilter::candidate_cost(&unfavorable, 1000, 1000),
+            CandidateFilter::candidate_cost(&unfavorable),
             MAX_CANDIDATE_COST
         );
     }
@@ -751,21 +606,17 @@ mod test {
     fn candidate_weight_clamped() {
         let c = Candidate {
             depth: 500.0,
-            num_dependents: 500,
             encompasses_weight: 500.0,
             dead_end: true,
             urgency: 0.0001,
             ..weighted_candidate()
         };
-        assert_eq!(
-            CandidateFilter::candidate_weight(&c, 1, 1),
-            MIN_CANDIDATE_WEIGHT
-        );
+        assert_eq!(CandidateFilter::candidate_weight(&c), MIN_CANDIDATE_WEIGHT);
     }
 
-    /// Verifies that candidates with higher absolute velocity get slightly less weight.
+    /// Verifies that candidates with higher positive velocity get slightly more weight.
     #[test]
-    fn higher_velocity_less_weight() {
+    fn positive_velocity_more_weight() {
         let base = Candidate {
             exercise_score: 2.0,
             velocity: Some(1.0),
@@ -776,14 +627,14 @@ mod test {
             ..base.clone()
         };
         assert!(
-            CandidateFilter::candidate_weight(&base, 1, 1)
-                < CandidateFilter::candidate_weight(&low_velocity, 1, 1)
+            CandidateFilter::candidate_weight(&base)
+                > CandidateFilter::candidate_weight(&low_velocity)
         );
     }
 
-    /// Verifies that negative velocity also reduces weight via the absolute value.
+    /// Verifies that negative velocity raises cost and reduces weight.
     #[test]
-    fn negative_velocity_reduces_weight() {
+    fn negative_velocity_less_weight() {
         let base = Candidate {
             exercise_score: 2.0,
             ..weighted_candidate()
@@ -793,8 +644,7 @@ mod test {
             ..base.clone()
         };
         assert!(
-            CandidateFilter::candidate_weight(&negative, 1, 1)
-                < CandidateFilter::candidate_weight(&base, 1, 1)
+            CandidateFilter::candidate_weight(&negative) < CandidateFilter::candidate_weight(&base)
         );
     }
 
@@ -810,12 +660,10 @@ mod test {
             ..base.clone()
         };
         assert!(
-            CandidateFilter::candidate_cost(&stagnant, 1, 1)
-                < CandidateFilter::candidate_cost(&base, 1, 1)
+            CandidateFilter::candidate_cost(&stagnant) < CandidateFilter::candidate_cost(&base)
         );
         assert!(
-            CandidateFilter::candidate_weight(&stagnant, 1, 1)
-                > CandidateFilter::candidate_weight(&base, 1, 1)
+            CandidateFilter::candidate_weight(&stagnant) > CandidateFilter::candidate_weight(&base)
         );
     }
 
@@ -831,19 +679,17 @@ mod test {
             ..base.clone()
         };
         assert!(
-            CandidateFilter::candidate_cost(&stagnant, 1, 1)
-                > CandidateFilter::candidate_cost(&base, 1, 1)
+            CandidateFilter::candidate_cost(&stagnant) > CandidateFilter::candidate_cost(&base)
         );
         assert!(
-            CandidateFilter::candidate_weight(&stagnant, 1, 1)
-                < CandidateFilter::candidate_weight(&base, 1, 1)
+            CandidateFilter::candidate_weight(&stagnant) < CandidateFilter::candidate_weight(&base)
         );
     }
 
-    /// Verifies that velocity above the stagnation threshold does not trigger the stagnation
-    /// bonus or penalty.
+    /// Verifies that velocity above the stagnation threshold only gets the directional velocity
+    /// adjustment, without any stagnation bonus or penalty.
     #[test]
-    fn non_stagnant_velocity_no_bonus_or_penalty() {
+    fn positive_velocity_reduces_cost() {
         let base = Candidate {
             exercise_score: 2.0,
             ..weighted_candidate()
@@ -852,13 +698,26 @@ mod test {
             velocity: Some(0.5),
             ..base.clone()
         };
+        assert!(CandidateFilter::candidate_cost(&active) < CandidateFilter::candidate_cost(&base));
         assert!(
-            CandidateFilter::candidate_cost(&active, 1, 1)
-                > CandidateFilter::candidate_cost(&base, 1, 1)
+            CandidateFilter::candidate_weight(&active) > CandidateFilter::candidate_weight(&base)
         );
+    }
+
+    /// Verifies that non-stagnant negative velocity increases cost and reduces weight.
+    #[test]
+    fn negative_velocity_increases_cost() {
+        let base = Candidate {
+            exercise_score: 2.0,
+            ..weighted_candidate()
+        };
+        let active = Candidate {
+            velocity: Some(-0.5),
+            ..base.clone()
+        };
+        assert!(CandidateFilter::candidate_cost(&active) > CandidateFilter::candidate_cost(&base));
         assert!(
-            CandidateFilter::candidate_weight(&active, 1, 1)
-                < CandidateFilter::candidate_weight(&base, 1, 1)
+            CandidateFilter::candidate_weight(&active) < CandidateFilter::candidate_weight(&base)
         );
     }
 

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -18,73 +18,52 @@ use crate::{
     scheduler::{Candidate, SchedulerData, review_knocker::KnockoutResult},
 };
 
-/// The minimum weight for each candidate. This is used to prevent any candidate from becoming too
-/// unlikely to be selected.
-const MIN_WEIGHT: f32 = 100.0;
+/// The minimum candidate cost.
+const MIN_CANDIDATE_COST: f32 = 0.25;
 
-/// The part of the weight that depends on the exercise's score will (5.0 - score) times this
-/// factor.
-const EXERCISE_SCORE_WEIGHT_FACTOR: f32 = 200.0;
+/// The maximum candidate cost.
+const MAX_CANDIDATE_COST: f32 = 1000.0;
 
-/// The factor used to compute the part of the weight that depends on how many other units the
-/// exercise is encompassed by in the initial batch.
-const ENCOMPASSED_FACTOR: f32 = -250.0;
+/// Coefficient applied to the depth term in the candidate cost.
+const DEPTH_COST_COEFFICIENT: f32 = 0.8;
 
-/// The factor used to compute the part of the weight that depends on how many units the exercise
-/// encompasses.
-const ENCOMPASSES_FACTOR: f32 = 1000.0;
+/// Coefficient applied to the number of dependents term in the candidate cost.
+const NUM_DEPENDENTS_COST_COEFFICIENT: f32 = 0.6;
 
-/// The part of the weight that depends on the depth of the candidate will be the product of the
-/// depth and this factor.
-const DEPTH_WEIGHT_FACTOR: f32 = 500.0;
+/// Coefficient applied to the coverage term in the candidate cost.
+const ENCOMPASSES_COST_COEFFICIENT: f32 = 0.55;
 
-/// The part of the weight that depends on the number of dependents of the lesson and course of the
-/// candidate will be the product of the number of dependents and this factor.
-const NUM_DEPENDENTS_WEIGHT_FACTOR: f32 = 250.0;
+/// Coefficient applied to the redundancy term in the candidate cost.
+const ENCOMPASSED_COST_COEFFICIENT: f32 = 1.0;
 
-/// The part of the weight that depends on whether the candidate was found at a dead-end in the
-/// graph.
-const DEAD_WEIGHT_FACTOR: f32 = 1000.0;
+/// Coefficient applied to the scheduled frequency term in the candidate cost.
+const SCHEDULED_FREQUENCY_COST_COEFFICIENT: f32 = 0.9;
 
-/// The part of the weight that depends on the number of times this exercise is scheduled during the
-/// run of the program will be capped at this value. Each time an exercise is scheduled, this
-/// portion of the weight is reduced by a factor.
-const MAX_SCHEDULED_WEIGHT: f32 = 1000.0;
+/// Coefficient applied to the number of trials term in the candidate cost.
+const NUM_TRIALS_COST_COEFFICIENT: f32 = 0.6;
 
-/// The factor by which the weight is mulitiplied every time the same exercise is scheduled during a
-/// single run of the program.
-const SCHEDULED_FACTOR: f32 = 0.5;
+/// Coefficient applied to the lesson candidate frequency term in the candidate cost.
+const LESSON_FREQUENCY_COST_COEFFICIENT: f32 = 0.45;
 
-/// The part of the weight that depends on the number of trials for that exercise will be capped at
-/// this value. Each time an exercise is scheduled, this portion of the weight is reduced by a
-/// factor.
-const MAX_NUM_TRIALS_WEIGHT: f32 = 1000.0;
+/// Coefficient applied to the course candidate frequency term in the candidate cost.
+const COURSE_FREQUENCY_COST_COEFFICIENT: f32 = 0.35;
 
-/// The factor by which the weight is mulitiplied when the number of trials is increased.
-const NUM_TRIALS_FACTOR: f32 = 0.75;
-
-/// The maximum weight that depends on the frequency of exercises from the same lesson. The weight
-/// will be divided equally among all the exercises from the same lesson.
-const MAX_LESSON_FREQUENCY_WEIGHT: f32 = 1000.0;
-
-/// The maximum weight that depends on the frequency of exercises from the same course. The weight
-/// will be divided equally among all the exercises from the same course.
-const MAX_COURSE_FREQUENCY_WEIGHT: f32 = 1000.0;
+/// Reduction applied to the log-cost of dead-end candidates.
+const DEAD_END_COST_BONUS: f32 = 0.8;
 
 /// The batch size will be adjusted if there are not enough candidates (at least three times the
 /// batch size) to create a batch of the size specified in the scheduler options. This value is the
 /// minimum value for such an adjustment.
 const MIN_DYNAMIC_BATCH_SIZE: usize = 10;
 
-/// The factor used to multiply the absolute value of the velocity to compute its contribution to
-/// the weight.
-const VELOCITY_WEIGHT_FACTOR: f32 = 250.0;
+/// Coefficient applied to the absolute value of the velocity in the candidate cost.
+const VELOCITY_COST_COEFFICIENT: f32 = 0.2;
 
-/// The part of the weight added to non-mastered candidates with a stagnant velocity.
-const STAGNANT_VELOCITY_WEIGHT: f32 = 2000.0;
+/// Reduction applied to the log-cost of non-mastered candidates with stagnant velocity.
+const STAGNANT_UNMASTERED_COST_BONUS: f32 = 1.0;
 
-/// The part of the weight substracted to mastered candidates with a stagnant velocity.
-const STAGNANT_VELOCITY_PENALTY: f32 = -2000.0;
+/// Penalty applied to the log-cost of mastered candidates with stagnant velocity.
+const STAGNANT_MASTERED_COST_PENALTY: f32 = 1.0;
 
 /// The velocity threshold under which a candidate is considered to be stagnant.
 const STAGNANT_VELOCITY_THRESHOLD: f32 = 0.2;
@@ -138,92 +117,48 @@ impl CandidateFilter {
     }
 
     /// Computes the cost assigned to a candidate that will be used to select it during the
-    /// filtering phase. The weight is based on the following factors:
+    /// filtering phase. The cost is built in log-space so that individual factors can be summed,
+    /// then converted back to linear space by exponentiation. Lower cost means a candidate should
+    /// be selected more often.
     ///
-    /// 1. The candidate's exercise score. A higher score is assigned less weight to give them
-    ///    precedence over candidates with lower scores.
-    /// 2. The number of units the exercise is encompassed by in the initial batch. A higher
-    ///    negative weight is assigned to exercises with a higher value to avoid selecting these
-    ///    exercises.
-    /// 3. The number of units the exercise encompasses. Exercises that encompass more units are
-    ///    given more weight since they implicitly review more material.
-    /// 4. The number of hops taken by the graph search to find the candidate. A higher number of
-    ///    hops is assigned more weight to give precedence to candidates from more advanced
-    ///    material.
-    /// 5. The number of dependents of the lesson and course of the candidate. Exercises from
-    ///    lessons and courses that unlock more units are given higher weight.
-    /// 6. The frequency with which the candidate has been scheduled during the run of the
-    ///    scheduler. A higher frequency is assigned less weight to avoid selecting the same
-    ///    exercises too often during the same session.
-    /// 7. The number of trials for that candidate. A higher number of trials is assigned less
-    ///    weight to favor exercises that have been practiced fewer times.
-    /// 8. The number of candidates in the same lesson. The more candidates there are in the same
-    ///     lesson, the less weight each candidate is assigned to avoid selecting too many exercises
-    ///     from the same lesson.
-    /// 9. The number of candidates in the same course. The same logic applies as for the lesson
-    ///     frequency.
-    /// 10. Whether the candidate comes from a dead-end in the traversal. Dead-end candidates get a
-    ///     fixed bonus to prioritize the learner's frontier.
-    /// 11. The candidate's score velocity. The absolute value of the velocity is multiplied by a
-    ///     factor.
-    /// 12. Whether the candidate has a stagnant velocity. Non-mastered candidates with a stagnant
-    ///     velocity get a weight bonus, while mastered candidates with a stagnant velocity get a
-    ///     penalty.
+    /// 1. Greater depth lowers the cost.
+    /// 2. More dependents lower the cost.
+    /// 3. Higher coverage lowers the cost.
+    /// 4. Being encompassed by other candidates raises the cost.
+    /// 5. More repeated scheduling raises the cost.
+    /// 6. More trials raise the cost.
+    /// 7. Higher lesson and course candidate frequency raise the cost.
+    /// 8. Dead-end candidates get a cost reduction.
+    /// 9. Higher absolute velocity raises the cost slightly.
+    /// 10. Stagnant non-mastered candidates get a cost reduction.
+    /// 11. Stagnant mastered candidates get a cost penalty.
     fn candidate_cost(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
-        // A part of the score will depend on the score of the exercise.
-        let mut weight = EXERCISE_SCORE_WEIGHT_FACTOR * (5.0 - c.exercise_score).max(0.0);
+        let mut log_cost = 0.0;
+        log_cost -= DEPTH_COST_COEFFICIENT * c.depth.ln_1p();
+        log_cost -= NUM_DEPENDENTS_COST_COEFFICIENT * (c.num_dependents as f32).ln_1p();
+        log_cost -= ENCOMPASSES_COST_COEFFICIENT * c.encompasses_weight.ln_1p();
+        log_cost += ENCOMPASSED_COST_COEFFICIENT * c.encompassed_weight.ln_1p();
+        log_cost += SCHEDULED_FREQUENCY_COST_COEFFICIENT * c.frequency as f32;
+        log_cost += NUM_TRIALS_COST_COEFFICIENT * (c.num_trials as f32).ln_1p();
+        log_cost += LESSON_FREQUENCY_COST_COEFFICIENT * (lesson_freq.max(1) as f32).ln();
+        log_cost += COURSE_FREQUENCY_COST_COEFFICIENT * (course_freq.max(1) as f32).ln();
 
-        // A part of the score will depend on the weight with which the exercise is encompassed
-        // by other exercises in the initial batch.
-        weight += ENCOMPASSED_FACTOR * c.encompassed_weight.ln_1p();
-
-        // A part of the score will depend on how many units this exercises encompasses. Exercises
-        // that encompass more units should be prioritized since they implicitly review more
-        // material.
-        weight += ENCOMPASSES_FACTOR * c.encompasses_weight.ln_1p();
-
-        // A part of the score will depend on the number of hops that were needed to reach
-        // the candidate.
-        weight += DEPTH_WEIGHT_FACTOR * c.depth.ln_1p();
-
-        // A part of the weight is based on the number of dependents of the lesson and course of the
-        // candidate.
-        weight += NUM_DEPENDENTS_WEIGHT_FACTOR * (c.num_dependents as f32).ln_1p();
-
-        // A part of the weight is based on the frequency with which the exercise has been
-        // scheduled.
-        weight += MAX_SCHEDULED_WEIGHT * SCHEDULED_FACTOR.powf(c.frequency as f32);
-
-        // A part of the weight is based on the number of trials for that exercise.
-        weight += MAX_NUM_TRIALS_WEIGHT * NUM_TRIALS_FACTOR.powf(c.num_trials as f32);
-
-        // A part of the weight is based on the number of candidates in the same lesson.
-        weight += MAX_LESSON_FREQUENCY_WEIGHT / lesson_freq.max(1) as f32;
-
-        // A part of the weight is based on the number of candidates in the same course.
-        weight += MAX_COURSE_FREQUENCY_WEIGHT / course_freq.max(1) as f32;
-
-        // A fixed part of the score depends on whether the candidate is at a dead-end.
         if c.dead_end {
-            weight += DEAD_WEIGHT_FACTOR;
+            log_cost -= DEAD_END_COST_BONUS;
         }
 
-        // A part of the weight is based on the candidate's score velocity. All exercises get a
-        // boost based on the absolute value of the velocity. Stagnant exercises get a boost or a
-        // penalty depending on whether they are mastered.
         if let Some(velocity) = c.velocity {
-            weight += VELOCITY_WEIGHT_FACTOR * velocity.abs();
+            log_cost += VELOCITY_COST_COEFFICIENT * velocity.abs();
             if velocity.abs() < STAGNANT_VELOCITY_THRESHOLD {
                 if c.exercise_score >= MASTERED_SCORE_THRESHOLD {
-                    weight += STAGNANT_VELOCITY_PENALTY;
+                    log_cost += STAGNANT_MASTERED_COST_PENALTY;
                 } else {
-                    weight += STAGNANT_VELOCITY_WEIGHT;
+                    log_cost -= STAGNANT_UNMASTERED_COST_BONUS;
                 }
             }
         }
 
-        // Give each candidates a minimum weight.
-        weight.max(MIN_WEIGHT)
+        log_cost.exp().clamp(MIN_CANDIDATE_COST, MAX_CANDIDATE_COST)
     }
 
     /// Computes the weight assigned to a candidate that will be used to select it during the
@@ -457,6 +392,14 @@ mod test {
     use super::*;
     use crate::scheduler::Candidate;
 
+    /// Creates a candidate with default values and unit urgency.
+    fn weighted_candidate() -> Candidate {
+        Candidate {
+            urgency: 1.0,
+            ..Default::default()
+        }
+    }
+
     /// Verifies that the batch size is adjusted based on the number of candidates.
     #[test]
     fn dynamic_batch_size() {
@@ -567,14 +510,17 @@ mod test {
         let remainder = vec![
             Candidate {
                 exercise_id: Ustr::from("exercise2"),
+                urgency: 1.0,
                 ..Default::default()
             },
             Candidate {
                 exercise_id: Ustr::from("exercise3"),
+                urgency: 1.0,
                 ..Default::default()
             },
             Candidate {
                 exercise_id: Ustr::from("exercise4"),
+                urgency: 1.0,
                 ..Default::default()
             },
         ];
@@ -619,10 +565,10 @@ mod test {
     /// Verifies that candidates that took more hops to reach are given more weight.
     #[test]
     fn more_hops_more_weight() {
-        let c1 = Candidate::default();
+        let c1 = weighted_candidate();
         let c2 = Candidate {
             depth: 10.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -633,10 +579,10 @@ mod test {
     /// Verifies that candidates with more dependents are given more weight.
     #[test]
     fn more_dependents_more_weight() {
-        let c1 = Candidate::default();
+        let c1 = weighted_candidate();
         let c2 = Candidate {
             num_dependents: 50,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -644,20 +590,20 @@ mod test {
         );
     }
 
-    /// Verifies that candidates with a higher score are given less weight.
+    /// Verifies that candidates with higher urgency are given more weight.
     #[test]
-    fn higher_exercise_score_less_weight() {
+    fn higher_urgency_more_weight() {
         let c1 = Candidate {
-            exercise_score: 5.0,
+            urgency: 1.0,
             ..Default::default()
         };
         let c2 = Candidate {
-            exercise_score: 1.0,
+            urgency: 0.25,
             ..Default::default()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
-                < CandidateFilter::candidate_weight(&c2, 1, 1)
+                > CandidateFilter::candidate_weight(&c2, 1, 1)
         );
     }
 
@@ -666,11 +612,11 @@ mod test {
     fn more_scheduled_frequency_less_weight() {
         let c1 = Candidate {
             frequency: 5,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let c2 = Candidate {
             frequency: 1,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -683,11 +629,11 @@ mod test {
     fn fewer_trials_more_weight() {
         let c1 = Candidate {
             num_trials: 5,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let c2 = Candidate {
             num_trials: 1,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -698,7 +644,7 @@ mod test {
     /// Verifies that candidates from lessons with more candidates are given less weight.
     #[test]
     fn higher_lesson_frequency_less_weight() {
-        let c = Candidate::default();
+        let c = weighted_candidate();
         assert!(
             CandidateFilter::candidate_weight(&c, 10, 1)
                 < CandidateFilter::candidate_weight(&c, 3, 1)
@@ -793,7 +739,7 @@ mod test {
     /// Verifies that candidates from courses with more candidates are given less weight.
     #[test]
     fn higher_course_frequency_less_weight() {
-        let c = Candidate::default();
+        let c = weighted_candidate();
         assert!(
             CandidateFilter::candidate_weight(&c, 1, 10)
                 < CandidateFilter::candidate_weight(&c, 1, 3)
@@ -806,11 +752,11 @@ mod test {
     fn higher_encompassed_weight_less_weight() {
         let c1 = Candidate {
             encompassed_weight: 10.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let c2 = Candidate {
             encompassed_weight: 3.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -823,11 +769,11 @@ mod test {
     fn higher_encompasses_weight_more_weight() {
         let c1 = Candidate {
             encompasses_weight: 10.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let c2 = Candidate {
             encompasses_weight: 3.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         assert!(
             CandidateFilter::candidate_weight(&c1, 1, 1)
@@ -835,50 +781,59 @@ mod test {
         );
     }
 
-    /// Verifies that dead-end candidates get a fixed additional weight.
+    /// Verifies that dead-end candidates have lower cost and therefore more weight.
     #[test]
-    fn dead_end_fixed_weight_bonus() {
-        let base = Candidate::default();
+    fn dead_end_more_weight() {
+        let base = weighted_candidate();
         let dead_end = Candidate {
             dead_end: true,
-            ..Default::default()
+            ..weighted_candidate()
         };
 
-        let base_weight = CandidateFilter::candidate_weight(&base, 1, 1);
-        let dead_end_weight = CandidateFilter::candidate_weight(&dead_end, 1, 1);
-        assert_eq!(dead_end_weight - base_weight, DEAD_WEIGHT_FACTOR);
-    }
-
-    /// Verifies that the minimum weight is applied to candidates.
-    #[test]
-    fn minimum_weight() {
-        // Create a candidate that should have a very low weight.
-        let c = Candidate {
-            exercise_score: 5.0,
-            num_trials: 1000,
-            frequency: 1000,
-            ..Default::default()
-        };
-        assert_eq!(
-            CandidateFilter::candidate_weight(
-                &Candidate {
-                    encompassed_weight: 100.0,
-                    ..c
-                },
-                1000,
-                1000
-            ),
-            MIN_WEIGHT
+        assert!(
+            CandidateFilter::candidate_cost(&dead_end, 1, 1)
+                < CandidateFilter::candidate_cost(&base, 1, 1)
+        );
+        assert!(
+            CandidateFilter::candidate_weight(&dead_end, 1, 1)
+                > CandidateFilter::candidate_weight(&base, 1, 1)
         );
     }
 
-    /// Verifies that candidates with higher absolute velocity get more weight.
+    /// Verifies that candidate costs are clamped into the configured range.
     #[test]
-    fn higher_velocity_more_weight() {
+    fn candidate_cost_clamped() {
+        let favorable = Candidate {
+            depth: 500.0,
+            num_dependents: 500,
+            encompasses_weight: 500.0,
+            dead_end: true,
+            ..weighted_candidate()
+        };
+        let unfavorable = Candidate {
+            num_trials: 1000,
+            frequency: 1000,
+            encompassed_weight: 1000.0,
+            velocity: Some(10.0),
+            ..weighted_candidate()
+        };
+        assert_eq!(
+            CandidateFilter::candidate_cost(&favorable, 1, 1),
+            MIN_CANDIDATE_COST
+        );
+        assert_eq!(
+            CandidateFilter::candidate_cost(&unfavorable, 1000, 1000),
+            MAX_CANDIDATE_COST
+        );
+    }
+
+    /// Verifies that candidates with higher absolute velocity get slightly less weight.
+    #[test]
+    fn higher_velocity_less_weight() {
         let base = Candidate {
             exercise_score: 2.0,
             velocity: Some(1.0),
-            ..Default::default()
+            ..weighted_candidate()
         };
         let low_velocity = Candidate {
             velocity: Some(0.5),
@@ -886,16 +841,16 @@ mod test {
         };
         assert!(
             CandidateFilter::candidate_weight(&base, 1, 1)
-                > CandidateFilter::candidate_weight(&low_velocity, 1, 1)
+                < CandidateFilter::candidate_weight(&low_velocity, 1, 1)
         );
     }
 
-    /// Verifies that negative velocity also boosts weight via the absolute value.
+    /// Verifies that negative velocity also reduces weight via the absolute value.
     #[test]
-    fn negative_velocity_boosts_weight() {
+    fn negative_velocity_reduces_weight() {
         let base = Candidate {
             exercise_score: 2.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let negative = Candidate {
             velocity: Some(-1.0),
@@ -903,37 +858,46 @@ mod test {
         };
         assert!(
             CandidateFilter::candidate_weight(&negative, 1, 1)
-                > CandidateFilter::candidate_weight(&base, 1, 1)
+                < CandidateFilter::candidate_weight(&base, 1, 1)
         );
     }
 
-    /// Verifies that stagnant non-mastered exercises get a weight bonus.
+    /// Verifies that stagnant non-mastered exercises get a cost reduction and more weight.
     #[test]
     fn stagnant_low_score_gets_bonus() {
         let base = Candidate {
             exercise_score: 2.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let stagnant = Candidate {
             velocity: Some(0.05),
             ..base.clone()
         };
-        let base_weight = CandidateFilter::candidate_weight(&base, 1, 1);
-        let stagnant_weight = CandidateFilter::candidate_weight(&stagnant, 1, 1);
-        assert!(stagnant_weight > base_weight + STAGNANT_VELOCITY_WEIGHT - 100.0);
+        assert!(
+            CandidateFilter::candidate_cost(&stagnant, 1, 1)
+                < CandidateFilter::candidate_cost(&base, 1, 1)
+        );
+        assert!(
+            CandidateFilter::candidate_weight(&stagnant, 1, 1)
+                > CandidateFilter::candidate_weight(&base, 1, 1)
+        );
     }
 
-    /// Verifies that stagnant mastered exercises get a weight penalty.
+    /// Verifies that stagnant mastered exercises get a cost penalty and less weight.
     #[test]
     fn stagnant_high_score_gets_penalty() {
         let base = Candidate {
             exercise_score: 4.5,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let stagnant = Candidate {
             velocity: Some(0.05),
             ..base.clone()
         };
+        assert!(
+            CandidateFilter::candidate_cost(&stagnant, 1, 1)
+                > CandidateFilter::candidate_cost(&base, 1, 1)
+        );
         assert!(
             CandidateFilter::candidate_weight(&stagnant, 1, 1)
                 < CandidateFilter::candidate_weight(&base, 1, 1)
@@ -946,15 +910,19 @@ mod test {
     fn non_stagnant_velocity_no_bonus_or_penalty() {
         let base = Candidate {
             exercise_score: 2.0,
-            ..Default::default()
+            ..weighted_candidate()
         };
         let active = Candidate {
             velocity: Some(0.5),
             ..base.clone()
         };
-        let base_weight = CandidateFilter::candidate_weight(&base, 1, 1);
-        let active_weight = CandidateFilter::candidate_weight(&active, 1, 1);
-        let expected_diff = VELOCITY_WEIGHT_FACTOR * 0.5;
-        assert!((active_weight - base_weight - expected_diff).abs() < 1.0);
+        assert!(
+            CandidateFilter::candidate_cost(&active, 1, 1)
+                > CandidateFilter::candidate_cost(&base, 1, 1)
+        );
+        assert!(
+            CandidateFilter::candidate_weight(&active, 1, 1)
+                < CandidateFilter::candidate_weight(&base, 1, 1)
+        );
     }
 }

--- a/src/scheduler/filter.rs
+++ b/src/scheduler/filter.rs
@@ -18,47 +18,50 @@ use crate::{
     scheduler::{Candidate, SchedulerData, review_knocker::KnockoutResult},
 };
 
+/// The minimum candidate weight.
+const MIN_CANDIDATE_WEIGHT: f32 = 0.01;
+
 /// The minimum candidate cost.
 const MIN_CANDIDATE_COST: f32 = 0.25;
 
 /// The maximum candidate cost.
-const MAX_CANDIDATE_COST: f32 = 1000.0;
+const MAX_CANDIDATE_COST: f32 = 100.0;
 
 /// Coefficient applied to the depth term in the candidate cost.
-const DEPTH_COST_COEFFICIENT: f32 = 0.8;
+const DEPTH_COST_COEFFICIENT: f32 = 0.6;
 
 /// Coefficient applied to the number of dependents term in the candidate cost.
-const NUM_DEPENDENTS_COST_COEFFICIENT: f32 = 0.6;
+const NUM_DEPENDENTS_COST_COEFFICIENT: f32 = 0.45;
 
 /// Coefficient applied to the coverage term in the candidate cost.
-const ENCOMPASSES_COST_COEFFICIENT: f32 = 0.55;
+const ENCOMPASSES_COST_COEFFICIENT: f32 = 0.45;
 
 /// Coefficient applied to the redundancy term in the candidate cost.
-const ENCOMPASSED_COST_COEFFICIENT: f32 = 1.0;
+const ENCOMPASSED_COST_COEFFICIENT: f32 = 0.8;
 
 /// Coefficient applied to the scheduled frequency term in the candidate cost.
-const SCHEDULED_FREQUENCY_COST_COEFFICIENT: f32 = 0.9;
+const SCHEDULED_FREQUENCY_COST_COEFFICIENT: f32 = 0.7;
 
 /// Coefficient applied to the number of trials term in the candidate cost.
-const NUM_TRIALS_COST_COEFFICIENT: f32 = 0.6;
+const NUM_TRIALS_COST_COEFFICIENT: f32 = 0.45;
 
 /// Coefficient applied to the lesson candidate frequency term in the candidate cost.
-const LESSON_FREQUENCY_COST_COEFFICIENT: f32 = 0.45;
+const LESSON_FREQUENCY_COST_COEFFICIENT: f32 = 0.35;
 
 /// Coefficient applied to the course candidate frequency term in the candidate cost.
-const COURSE_FREQUENCY_COST_COEFFICIENT: f32 = 0.35;
+const COURSE_FREQUENCY_COST_COEFFICIENT: f32 = 0.25;
 
 /// Reduction applied to the log-cost of dead-end candidates.
-const DEAD_END_COST_BONUS: f32 = 0.8;
+const DEAD_END_COST_BONUS: f32 = 0.6;
 
 /// Coefficient applied to the absolute value of the velocity in the candidate cost.
-const VELOCITY_COST_COEFFICIENT: f32 = 0.2;
+const VELOCITY_COST_COEFFICIENT: f32 = 0.15;
 
 /// Reduction applied to the log-cost of non-mastered candidates with stagnant velocity.
-const STAGNANT_UNMASTERED_COST_BONUS: f32 = 1.0;
+const STAGNANT_UNMASTERED_COST_BONUS: f32 = 0.7;
 
 /// Penalty applied to the log-cost of mastered candidates with stagnant velocity.
-const STAGNANT_MASTERED_COST_PENALTY: f32 = 1.0;
+const STAGNANT_MASTERED_COST_PENALTY: f32 = 0.7;
 
 /// The velocity threshold under which a candidate is considered to be stagnant.
 const STAGNANT_VELOCITY_THRESHOLD: f32 = 0.2;
@@ -167,7 +170,7 @@ impl CandidateFilter {
     /// "expensive" it is to schedule the exercise.
     fn candidate_weight(c: &Candidate, lesson_freq: u32, course_freq: u32) -> f32 {
         let cost = Self::candidate_cost(c, lesson_freq, course_freq);
-        c.urgency / cost.sqrt()
+        (c.urgency / cost.sqrt()).max(MIN_CANDIDATE_WEIGHT)
     }
 
     /// Takes a list of candidates and randomly selects `num_to_select` candidates among them. Each

--- a/src/scheduler/unit_scorer.rs
+++ b/src/scheduler/unit_scorer.rs
@@ -857,4 +857,61 @@ mod test {
         assert_eq!(Some(3), cache.get_exercise_num_trials(exercise_id)?);
         Ok(())
     }
+
+    /// Verifies that urgency is cached along the exercise scores.
+    #[test]
+    fn get_urgency() -> Result<()> {
+        // Create a test library and send some scores.
+        let temp_dir = tempfile::tempdir()?;
+        let library = init_test_simulation(temp_dir.path(), &TEST_LIBRARY)?;
+        let scheduler_data = library.get_scheduler_data();
+        let mut cache = UnitScorer::new(scheduler_data, SchedulerOptions::default());
+        let exercise_id = Ustr::from("0::0::0");
+        let day = 86_400;
+        cache.set_override_timestamp(Some(4 * day));
+        library.score_exercise(exercise_id, MasteryScore::Four, day)?;
+        library.score_exercise(exercise_id, MasteryScore::Five, 2 * day)?;
+
+        // Retrieve the urgency twice. The second time should hit the cache.
+        assert!(!cache.exercise_cache.borrow().contains_key(&exercise_id));
+        let initial_urgency = cache.get_exercise_urgency(exercise_id)?;
+        assert!(cache.exercise_cache.borrow().contains_key(&exercise_id));
+        assert_eq!(initial_urgency, cache.get_exercise_urgency(exercise_id)?);
+
+        // Add another score and invalidate the cache. The updated urgency should reflect the more
+        // recent successful review.
+        library.score_exercise(exercise_id, MasteryScore::Five, 3 * day)?;
+        cache.invalidate_cached_score(exercise_id);
+        let updated_urgency = cache.get_exercise_urgency(exercise_id)?;
+        assert!(updated_urgency < initial_urgency);
+        Ok(())
+    }
+
+    /// Verifies that velocity is cached along the exercise scores.
+    #[test]
+    fn get_velocity() -> Result<()> {
+        // Create a test library and send some scores.
+        let temp_dir = tempfile::tempdir()?;
+        let library = init_test_simulation(temp_dir.path(), &TEST_LIBRARY)?;
+        let scheduler_data = library.get_scheduler_data();
+        let cache = UnitScorer::new(scheduler_data, SchedulerOptions::default());
+        let exercise_id = Ustr::from("0::0::0");
+        let day = 86_400;
+        library.score_exercise(exercise_id, MasteryScore::Four, day)?;
+        library.score_exercise(exercise_id, MasteryScore::Five, 2 * day)?;
+
+        // Retrieve the velocity twice. The second time should hit the cache.
+        assert!(!cache.exercise_cache.borrow().contains_key(&exercise_id));
+        let initial_velocity = cache.get_exercise_velocity(exercise_id)?;
+        assert!(cache.exercise_cache.borrow().contains_key(&exercise_id));
+        assert_eq!(initial_velocity, cache.get_exercise_velocity(exercise_id)?);
+
+        // Add another score and invalidate the cache. The updated velocity should reflect the
+        // newer lower score.
+        library.score_exercise(exercise_id, MasteryScore::Four, 3 * day)?;
+        cache.invalidate_cached_score(exercise_id);
+        let updated_velocity = cache.get_exercise_velocity(exercise_id)?;
+        assert!(updated_velocity.unwrap() < initial_velocity.unwrap());
+        Ok(())
+    }
 }

--- a/src/scheduler/unit_scorer.rs
+++ b/src/scheduler/unit_scorer.rs
@@ -24,7 +24,6 @@ pub(super) struct CachedScore {
     score: f32,
 
     /// The urgency of scheduling the unit, as a value between 0.0 and 1.0.
-    #[allow(dead_code)]
     urgency: f32,
 
     /// The velocity of learning, a measure of how quickly the score is improving or worsening over
@@ -248,7 +247,6 @@ impl UnitScorer {
     }
 
     /// Returns the urgency of scheduling the given exercise, as a value between 0.0 and 1.0.
-    #[allow(dead_code)]
     pub(super) fn get_exercise_urgency(&self, exercise_id: Ustr) -> Result<f32> {
         // Return the cached value if it exists.
         let cached_urgency = self

--- a/src/scheduler/unit_scorer.rs
+++ b/src/scheduler/unit_scorer.rs
@@ -265,7 +265,7 @@ impl UnitScorer {
             .exercise_cache
             .borrow()
             .get(&exercise_id)
-            .map(|s| s.score)
+            .map(|s| s.urgency)
             .unwrap_or_default();
         Ok(cached_urgency)
     }

--- a/src/scheduler/unit_scorer.rs
+++ b/src/scheduler/unit_scorer.rs
@@ -257,7 +257,7 @@ impl UnitScorer {
 
     /// Returns the urgency of scheduling the given exercise, as a value between 0.0 and 1.0.
     #[allow(dead_code)]
-    pub(super) fn get_exercise_urgency(&self, exercise_id: Ustr) -> Result<Option<f32>> {
+    pub(super) fn get_exercise_urgency(&self, exercise_id: Ustr) -> Result<f32> {
         // Return the cached value if it exists.
         let cached_urgency = self
             .exercise_cache
@@ -265,7 +265,7 @@ impl UnitScorer {
             .get(&exercise_id)
             .map(|c| c.urgency);
         if let Some(urgency) = cached_urgency {
-            return Ok(Some(urgency));
+            return Ok(urgency);
         }
 
         // Compute the exercise's score, which populates the cache. Then, retrieve the urgency from
@@ -275,7 +275,8 @@ impl UnitScorer {
             .exercise_cache
             .borrow()
             .get(&exercise_id)
-            .map(|s| s.urgency);
+            .and_then(|s| Some(s.urgency))
+            .unwrap_or_default();
         Ok(cached_urgency)
     }
 

--- a/src/scheduler/unit_scorer.rs
+++ b/src/scheduler/unit_scorer.rs
@@ -33,9 +33,6 @@ pub(super) struct CachedScore {
 
     /// The number of trials used to compute the score.
     num_trials: usize,
-
-    /// The number of days since the last trial.
-    last_seen: f32,
 }
 
 /// Contains the logic to score units based on their previous scores and rewards, as well as the
@@ -231,10 +228,6 @@ impl UnitScorer {
             .reward_scorer
             .score_rewards(&course_rewards, &lesson_rewards)
             .unwrap_or_default();
-        let now = self.now();
-        let last_seen = scores.first().map_or(0.0, |trial| {
-            ((now - trial.timestamp) as f32 / 86_400.0).max(0.0)
-        });
 
         // Apply the reward if it meets the criteria and cache the final score.
         let final_score = if self.reward_scorer.apply_reward(reward, &scores) {
@@ -249,7 +242,6 @@ impl UnitScorer {
                 urgency: score.urgency,
                 velocity: score.velocity,
                 num_trials: scores.len(),
-                last_seen,
             },
         );
         Ok(final_score)
@@ -275,7 +267,7 @@ impl UnitScorer {
             .exercise_cache
             .borrow()
             .get(&exercise_id)
-            .and_then(|s| Some(s.urgency))
+            .map(|s| s.score)
             .unwrap_or_default();
         Ok(cached_urgency)
     }
@@ -325,29 +317,6 @@ impl UnitScorer {
             .get(&exercise_id)
             .map(|s| s.num_trials);
         Ok(cached_num_trials)
-    }
-
-    /// Returns the number of days since the last trial for the given exercise.
-    pub(super) fn get_last_seen_days(&self, exercise_id: Ustr) -> Result<Option<f32>> {
-        // Return the cached value if it exists.
-        let cached_last_seen = self
-            .exercise_cache
-            .borrow()
-            .get(&exercise_id)
-            .map(|c| c.last_seen);
-        if let Some(last_seen) = cached_last_seen {
-            return Ok(Some(last_seen));
-        }
-
-        // Compute the exercise's score, which populates the cache. Then, retrieve the days since last
-        // seen from the cache.
-        self.get_exercise_score(exercise_id)?;
-        let cached_last_seen = self
-            .exercise_cache
-            .borrow()
-            .get(&exercise_id)
-            .map(|s| s.last_seen);
-        Ok(cached_last_seen)
     }
 
     /// Returns whether all the exercises in the unit have valid scores.
@@ -826,7 +795,6 @@ mod test {
                 urgency: 0.0,
                 velocity: None,
                 num_trials: 1,
-                last_seen: 0.0,
             },
         );
         cache.exercise_cache.borrow_mut().insert(
@@ -836,7 +804,6 @@ mod test {
                 urgency: 0.0,
                 velocity: None,
                 num_trials: 1,
-                last_seen: 0.0,
             },
         );
         cache
@@ -890,27 +857,6 @@ mod test {
         library.score_exercise(exercise_id, MasteryScore::Four, 3)?;
         cache.invalidate_cached_score(exercise_id);
         assert_eq!(Some(3), cache.get_exercise_num_trials(exercise_id)?);
-        Ok(())
-    }
-
-    /// Verifies that the number of days since last seen is computed and cached along with the score.
-    #[test]
-    fn get_last_seen_days() -> Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let library = init_test_simulation(temp_dir.path(), &TEST_LIBRARY)?;
-        let scheduler_data = library.get_scheduler_data();
-        let cache = UnitScorer::new(scheduler_data, SchedulerOptions::default());
-        let exercise_id = Ustr::from("0::0::0");
-        let two_days_ago = Utc::now().timestamp() - (2 * 86_400);
-        library.score_exercise(exercise_id, MasteryScore::Three, two_days_ago)?;
-
-        let last_seen = cache.get_last_seen_days(exercise_id)?;
-        assert!((last_seen.unwrap_or_default() - 2.0).abs() < 0.5);
-
-        library.score_exercise(exercise_id, MasteryScore::Four, Utc::now().timestamp())?;
-        cache.invalidate_cached_score(exercise_id);
-        let last_seen = cache.get_last_seen_days(exercise_id)?;
-        assert!(last_seen.unwrap_or_default() < 1.0);
         Ok(())
     }
 }


### PR DESCRIPTION
Redefine the weight to `urgency / sqrt(cost)` and simplify how the cost is computed.