### PR TITLE
Fix max_lessons_in_progress bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trane"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 description = "An automated system for learning complex skills"
 license = "AGPL-3.0-or-later"

--- a/src/course_library.rs
+++ b/src/course_library.rs
@@ -222,7 +222,7 @@ impl LocalCourseLibrary {
         lesson_manifest: &LessonManifest,
     ) -> Result<()> {
         // Verify that the IDs mentioned in the manifests are valid and agree with each other.
-        ensure!(!lesson_manifest.id.is_empty(), "ID in manifest is empty",);
+        ensure!(!lesson_manifest.id.is_empty(), "ID in manifest is empty");
         ensure!(
             lesson_manifest.course_id == course_manifest.id,
             "course_id in manifest for lesson {} does not match the manifest for course {}",
@@ -277,7 +277,7 @@ impl LocalCourseLibrary {
     /// Verifies that the IDs mentioned in the course manifest are valid.
     #[cfg_attr(coverage, coverage(off))]
     fn verify_course_manifest(course_manifest: &CourseManifest) -> Result<()> {
-        ensure!(!course_manifest.id.is_empty(), "ID in manifest is empty",);
+        ensure!(!course_manifest.id.is_empty(), "ID in manifest is empty");
         Ok(())
     }
 
@@ -609,8 +609,8 @@ impl CourseLibrary for LocalCourseLibrary {
         match unit_type {
             Some(UnitType::Course) => self
                 .course_map
-                .iter()
-                .filter_map(|(id, _)| {
+                .keys()
+                .filter_map(|id| {
                     if id.starts_with(prefix) {
                         Some(*id)
                     } else {
@@ -620,8 +620,8 @@ impl CourseLibrary for LocalCourseLibrary {
                 .collect(),
             Some(UnitType::Lesson) => self
                 .lesson_map
-                .iter()
-                .filter_map(|(id, _)| {
+                .keys()
+                .filter_map(|id| {
                     if id.starts_with(prefix) {
                         Some(*id)
                     } else {
@@ -631,8 +631,8 @@ impl CourseLibrary for LocalCourseLibrary {
                 .collect(),
             Some(UnitType::Exercise) => self
                 .exercise_map
-                .iter()
-                .filter_map(|(id, _)| {
+                .keys()
+                .filter_map(|id| {
                     if id.starts_with(prefix) {
                         Some(*id)
                     } else {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -700,6 +700,12 @@ impl DepthFirstScheduler {
         lessons_in_progress: &mut UstrSet,
         options: &SchedulerOptions,
     ) {
+        // Exit early if the lesson has no candidates, as is the case for blacklisted or
+        // filtered-out lessons.
+        if candidates.is_empty() {
+            return;
+        }
+
         let in_progress = match lesson_score {
             Some(score) => score <= options.target_window_opts.range.1,
             None => true,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -983,8 +983,7 @@ impl DepthFirstScheduler {
                     UnitFilter::LessonFilter { lesson_ids } => {
                         let mut candidates = Vec::new();
                         for lesson_id in lesson_ids {
-                            candidates
-                                .extend(self.get_candidates_from_lesson(lesson_id)?.into_iter());
+                            candidates.extend(self.get_candidates_from_lesson(lesson_id)?);
                         }
                         candidates
                     }

--- a/tests/blacklist_tests.rs
+++ b/tests/blacklist_tests.rs
@@ -10,9 +10,10 @@ use tempfile::TempDir;
 use trane::{
     blacklist::Blacklist,
     data::{
-        MasteryScore,
+        MasteryScore, SchedulerOptions,
         filter::{ExerciseFilter, UnitFilter},
     },
+    scheduler::ExerciseScheduler,
     test_utils::*,
 };
 
@@ -120,6 +121,56 @@ static LIBRARY: LazyLock<Vec<TestCourse>> = LazyLock::new(|| {
                 TestLesson {
                     id: TestId(3, Some(1), None),
                     dependencies: vec![TestId(3, Some(0), None)],
+                    encompassed: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
+        TestCourse {
+            id: TestId(4, None, None),
+            dependencies: vec![TestId(0, None, None)],
+            encompassed: vec![],
+            superseded: vec![],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(4, Some(0), None),
+                    dependencies: vec![],
+                    encompassed: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(4, Some(1), None),
+                    dependencies: vec![TestId(4, Some(0), None)],
+                    encompassed: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+            ],
+        },
+        TestCourse {
+            id: TestId(5, None, None),
+            dependencies: vec![TestId(0, None, None)],
+            encompassed: vec![],
+            superseded: vec![],
+            metadata: BTreeMap::default(),
+            lessons: vec![
+                TestLesson {
+                    id: TestId(5, Some(0), None),
+                    dependencies: vec![],
+                    encompassed: vec![],
+                    superseded: vec![],
+                    metadata: BTreeMap::default(),
+                    num_exercises: 10,
+                },
+                TestLesson {
+                    id: TestId(5, Some(1), None),
+                    dependencies: vec![TestId(5, Some(0), None)],
                     encompassed: vec![],
                     superseded: vec![],
                     metadata: BTreeMap::default(),
@@ -292,6 +343,56 @@ fn avoid_scheduling_exercises_in_blacklist() -> Result<()> {
                 exercise_id
             );
             assert_simulation_scores(exercise_ustr, &trane, &simulation.answer_history)?;
+        } else {
+            assert!(
+                !simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should not have been scheduled",
+                exercise_id
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Verifies that courses are still being scheduled even when many units are blacklisted. This is a
+/// regression test for a bug where blacklisted units were incorrectly counted towards the
+/// `max_lessons_in_progress` limit, prematurely capping the candidate search.
+#[test]
+fn schedule_courses_with_many_blacklisted_units() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let mut trane = init_test_simulation(temp_dir.path(), &LIBRARY)?;
+
+    // Tighten the max lessons in progress so the bug would manifest easily.
+    trane.set_scheduler_options(SchedulerOptions {
+        max_lessons_in_progress: 5,
+        ..SchedulerOptions::default()
+    });
+
+    // Blacklist all courses except the last one.
+    let course_blacklist = vec![
+        TestId(0, None, None),
+        TestId(1, None, None),
+        TestId(2, None, None),
+        TestId(3, None, None),
+        TestId(4, None, None),
+    ];
+    let mut simulation = TraneSimulation::new(500, Box::new(|_| Some(MasteryScore::Five)));
+    simulation.run_simulation(&mut trane, &course_blacklist, &None)?;
+
+    // Verify exercises from the non-blacklisted course were scheduled, and exercises from the
+    // blacklisted courses were not.
+    let exercise_ids = all_test_exercises(&LIBRARY);
+    for exercise_id in exercise_ids {
+        let exercise_ustr = exercise_id.to_ustr();
+        if !course_blacklist
+            .iter()
+            .any(|course_id| exercise_id.exercise_in_course(course_id))
+        {
+            assert!(
+                simulation.answer_history.contains_key(&exercise_ustr),
+                "exercise {:?} should have been scheduled",
+                exercise_id
+            );
         } else {
             assert!(
                 !simulation.answer_history.contains_key(&exercise_ustr),


### PR DESCRIPTION
Blacklisted or filtered out lessons were being counted towards this limit, causing empty batches when too many units were being blacklisted.